### PR TITLE
Replace calls of deprecated functions for getting subfields of a PVStructure

### DIFF
--- a/exampleServer/src/exampleServer.cpp
+++ b/exampleServer/src/exampleServer.cpp
@@ -66,9 +66,9 @@ bool ExampleServer::init()
     
     initPVRecord();
     PVFieldPtr pvField;
-    pvArgumentValue = getPVStructure()->getStringField("argument.value");
+    pvArgumentValue = getPVStructure()->getSubField<PVString>("argument.value");
     if(pvArgumentValue.get()==NULL) return false;
-    pvResultValue = getPVStructure()->getStringField("result.value");
+    pvResultValue = getPVStructure()->getSubField<PVString>("result.value");
     if(pvResultValue.get()==NULL) return false;
     pvTimeStamp.attach(getPVStructure()->getSubField("result.timeStamp"));
     return true;

--- a/src/pvAccess/channelLocal.cpp
+++ b/src/pvAccess/channelLocal.cpp
@@ -149,7 +149,7 @@ ChannelProcessLocalPtr ChannelProcessLocal::create(
         pvOptions = static_pointer_cast<PVStructure>(pvField);
         pvField = pvOptions->getSubField("nProcess");
         if(pvField) {
-            PVStringPtr pvString = pvOptions->getStringField("nProcess");
+            PVStringPtr pvString = pvOptions->getSubField<PVString>("nProcess");
             if(pvString) {
                 int size;
                 std::stringstream ss;

--- a/src/special/recordList.cpp
+++ b/src/special/recordList.cpp
@@ -61,20 +61,19 @@ bool RecordListRecord::init()
 {
     initPVRecord();
     PVStructurePtr pvStructure = getPVStructure();
-    database = pvStructure->getStringField("argument.database");
+    database = pvStructure->getSubField<PVString>("argument.database");
     if(database.get()==NULL) return false;
-    regularExpression = pvStructure->getStringField(
+    regularExpression = pvStructure->getSubField<PVString>(
         "argument.regularExpression");
     if(regularExpression.get()==NULL) return false;
-    status = pvStructure->getStringField("result.status");
+    status = pvStructure->getSubField<PVString>("result.status");
     if(status.get()==NULL) return false;
     PVFieldPtr pvField = pvStructure->getSubField("result.names");
     if(pvField.get()==NULL) {
         std::cerr << "no result.names" << std::endl;
         return false;
     }
-    name = static_pointer_cast<PVStringArray>(
-         pvStructure->getScalarArrayField("result.names",pvString));
+    name = pvStructure->getSubField<PVStringArray>("result.names");
     if(name.get()==NULL) return false;
     return true;
 }

--- a/src/special/traceRecord.cpp
+++ b/src/special/traceRecord.cpp
@@ -62,11 +62,11 @@ bool TraceRecord::init()
 {
     initPVRecord();
     PVStructurePtr pvStructure = getPVStructure();
-    pvRecordName = pvStructure->getStringField("argument.recordName");
+    pvRecordName = pvStructure->getSubField<PVString>("argument.recordName");
     if(!pvRecordName) return false;
-    pvLevel = pvStructure->getIntField("argument.level");
+    pvLevel = pvStructure->getSubField<PVInt>("argument.level");
     if(!pvLevel) return false;
-    pvResult = pvStructure->getStringField("result.status");
+    pvResult = pvStructure->getSubField<PVString>("result.status");
     if(!pvResult) return false;
     return true;
 }


### PR DESCRIPTION
<p>The non-template functions for getting subfields of a PVStructure, such as PVStructure::getIntField were marked as deprecated in the 4.4 release and now generate build warnings. I've replaced calls of these functions with calls of the template function getSubField, e.g. getSubField&lt;PVInt&gt;.</p>