### PR TITLE
Replace calls of deprecated PVStructure::getScalarArrayField

### DIFF
--- a/arrayPerformance/src/arrayPerformance.cpp
+++ b/arrayPerformance/src/arrayPerformance.cpp
@@ -59,9 +59,9 @@ bool ArrayPerformance::init()
 {
     
     initPVRecord();
-    PVScalarArrayPtr pvScalarArray = getPVStructure()->getScalarArrayField("value",pvLong);
-    if(!pvScalarArray) return false;
-    pvValue = static_pointer_cast<PVLongArray>(pvScalarArray);
+    PVLongArrayPtr pvLongArray = getPVStructure()->getSubField<PVLongArray>("value");
+    if(!pvLongArray) return false;
+    pvValue = pvLongArray;
     ArrayPerformancePtr xxx = dynamic_pointer_cast<ArrayPerformance>(getPtrSelf());
     arrayPerformanceThread = ArrayPerformanceThreadPtr(new ArrayPerformanceThread(xxx));
     arrayPerformanceThread->init();

--- a/exampleLink/src/exampleLink.cpp
+++ b/exampleLink/src/exampleLink.cpp
@@ -61,8 +61,7 @@ bool ExampleLink::init()
     PVStructurePtr pvStructure = getPVRecordStructure()->getPVStructure();
     pvTimeStamp.attach(pvStructure->getSubField("timeStamp"));
     pvAlarm.attach(pvStructure->getSubField("alarm"));
-    pvValue = static_pointer_cast<PVDoubleArray>(
-        pvStructure->getScalarArrayField("value",pvDouble));
+    pvValue = pvStructure->getSubField<PVDoubleArray>("value");
     if(!pvValue) {
         return false;
     }
@@ -93,8 +92,7 @@ bool ExampleLink::init()
              << status.getMessage() << endl;
         return false;
     }
-    getPVValue = static_pointer_cast<PVDoubleArray>(
-        getPVStructure->getScalarArrayField("value",pvDouble));
+    getPVValue = getPVStructure->getSubField<PVDoubleArray>("value");
     if(!getPVValue) {
         cout << getRecordName() << " get value not  PVDoubleArray" << endl;
         return false;

--- a/test/src/testPVCopy.cpp
+++ b/test/src/testPVCopy.cpp
@@ -144,7 +144,6 @@ static void testPVScalar(
 }
 
 static void testPVScalarArray(
-    ScalarType scalarType,
     string const & valueNameRecord,
     string const & valueNameCopy,
     PVRecordPtr const & pvRecord,
@@ -277,21 +276,21 @@ static void arrayTest()
     cout << "request " << request << endl << "pvRequest" << *pvRequest << endl ;
     pvCopy = PVCopy::create(pvRecord->getPVRecordStructure()->getPVStructure(),pvRequest,"");
     valueNameCopy = "value";
-    testPVScalarArray(pvDouble,valueNameRecord,valueNameCopy,pvRecord,pvCopy);
+    testPVScalarArray(valueNameRecord,valueNameCopy,pvRecord,pvCopy);
     request = "";
     valueNameRecord = "value";
     pvRequest = createRequest->createRequest(request);
     cout << "request " << request << endl << "pvRequest" << *pvRequest << endl ;
     pvCopy = PVCopy::create(pvRecord->getPVRecordStructure()->getPVStructure(),pvRequest,"");
     valueNameCopy = "value";
-    testPVScalarArray(pvDouble,valueNameRecord,valueNameCopy,pvRecord,pvCopy);
+    testPVScalarArray(valueNameRecord,valueNameCopy,pvRecord,pvCopy);
     request = "alarm,timeStamp,value";
     valueNameRecord = "value";
     pvRequest = createRequest->createRequest(request);
     cout << "request " << request << endl << "pvRequest" << *pvRequest << endl ;
     pvCopy = PVCopy::create(pvRecord->getPVRecordStructure()->getPVStructure(),pvRequest,"");
     valueNameCopy = "value";
-    testPVScalarArray(pvDouble,valueNameRecord,valueNameCopy,pvRecord,pvCopy);
+    testPVScalarArray(valueNameRecord,valueNameCopy,pvRecord,pvCopy);
     pvRecord->destroy();
 }
 

--- a/test/src/testPVCopy.cpp
+++ b/test/src/testPVCopy.cpp
@@ -160,14 +160,14 @@ static void testPVScalarArray(
     shared_vector<double> values(n);
     cout << endl;
     pvStructureRecord = pvRecord->getPVRecordStructure()->getPVStructure();
-    pvValueRecord = pvStructureRecord->getScalarArrayField(valueNameRecord,scalarType);
+    pvValueRecord = pvStructureRecord->getSubField<PVScalarArray>(valueNameRecord);
     for(size_t i=0; i<n; i++) values[i] = i;
     const shared_vector<const double> xxx(freeze(values));
     pvValueRecord->putFrom(xxx);
     StructureConstPtr structure = pvCopy->getStructure();
     cout << "structure from copy" << endl << *structure << endl;
     pvStructureCopy = pvCopy->createPVStructure();
-    pvValueCopy = pvStructureCopy->getScalarArrayField(valueNameCopy,scalarType);
+    pvValueCopy = pvStructureCopy->getSubField<PVScalarArray>(valueNameCopy);
     bitSet = BitSetPtr(new BitSet(pvStructureCopy->getNumberFields()));
     pvCopy->initCopy(pvStructureCopy, bitSet);
     cout << "after initCopy pvValueCopy " << *pvValueCopy << endl;


### PR DESCRIPTION
<p>Calls of the deprecated function PVStructure::getScalarArrayField have been replace by calls of the template function PVStructure::getSubField.
</p>