### PR TITLE
Use epicsGuard and epicsGuardRelease for lock handling

### DIFF
--- a/src/database/pvDatabase.cpp
+++ b/src/database/pvDatabase.cpp
@@ -8,6 +8,9 @@
  * @author mrk
  * @date 2012.11.21
  */
+
+#include <epicsGuard.h>
+
 #define epicsExportSharedSymbols
 
 #include <pv/pvDatabase.h>
@@ -40,25 +43,18 @@ PVDatabase::~PVDatabase()
 
 void PVDatabase::destroy()
 {
-    lock();
-    try {
-        if(isDestroyed) {
-            unlock();
-            return;
-        }
-        isDestroyed = true;
-        PVRecordMap::iterator iter;
-        while(true) {
-            iter = recordMap.begin();
-            if(iter==recordMap.end()) break;
-            PVRecordPtr pvRecord = (*iter).second;
-            recordMap.erase(iter);
-            if(pvRecord.get()!=NULL) pvRecord->destroy();
-        }
-        unlock();
-    } catch (...) {
-        unlock();
-        throw;
+    epicsGuard<epics::pvData::Mutex> guard(mutex);
+    if(isDestroyed) {
+        return;
+    }
+    isDestroyed = true;
+    PVRecordMap::iterator iter;
+    while(true) {
+        iter = recordMap.begin();
+        if(iter==recordMap.end()) break;
+        PVRecordPtr pvRecord = (*iter).second;
+        recordMap.erase(iter);
+        if(pvRecord.get()!=NULL) pvRecord->destroy();
     }
 }
 
@@ -72,101 +68,70 @@ void PVDatabase::unlock() {
 
 PVRecordPtr PVDatabase::findRecord(string const& recordName)
 {
-    lock();
-    try {
-        PVRecordPtr xxx;
-        if(isDestroyed) {
-            unlock();
-            return xxx;
-        }
-        PVRecordMap::iterator iter = recordMap.find(recordName);
-        if(iter!=recordMap.end()) {
-             unlock();
-             return (*iter).second;
-        }
-        unlock();
+    epicsGuard<epics::pvData::Mutex> guard(mutex);
+    PVRecordPtr xxx;
+    if(isDestroyed) {
         return xxx;
-    } catch(...) {
-        unlock();
-        throw;
     }
+    PVRecordMap::iterator iter = recordMap.find(recordName);
+    if(iter!=recordMap.end()) {
+         return (*iter).second;
+    }
+    return xxx;
 }
 
 PVStringArrayPtr PVDatabase::getRecordNames()
 {
-    lock();
-    try {
-        PVStringArrayPtr xxx;
-        if(isDestroyed) {
-            unlock();
-            return xxx;
-        }
-        PVStringArrayPtr pvStringArray = static_pointer_cast<PVStringArray>
-            (getPVDataCreate()->createPVScalarArray(pvString));
-        size_t len = recordMap.size();
-        shared_vector<string> names(len);
-        PVRecordMap::iterator iter;
-        size_t i = 0;
-        for(iter = recordMap.begin(); iter!=recordMap.end(); ++iter) {
-            names[i++] = (*iter).first;
-        }
-        shared_vector<const string> temp(freeze(names));
-        pvStringArray->replace(temp);
-        unlock();
-        return pvStringArray;
-    } catch(...) {
-        unlock();
-        throw;
+    epicsGuard<epics::pvData::Mutex> guard(mutex);
+    PVStringArrayPtr xxx;
+    if(isDestroyed) {
+        return xxx;
     }
+    PVStringArrayPtr pvStringArray = static_pointer_cast<PVStringArray>
+        (getPVDataCreate()->createPVScalarArray(pvString));
+    size_t len = recordMap.size();
+    shared_vector<string> names(len);
+    PVRecordMap::iterator iter;
+    size_t i = 0;
+    for(iter = recordMap.begin(); iter!=recordMap.end(); ++iter) {
+        names[i++] = (*iter).first;
+    }
+    shared_vector<const string> temp(freeze(names));
+    pvStringArray->replace(temp);
+    return pvStringArray;
 }
 
 bool PVDatabase::addRecord(PVRecordPtr const & record)
 {
-    lock();
-    try {
-        if(isDestroyed) {
-            unlock();
-            return false;
-        }
-        string recordName = record->getRecordName();
-        PVRecordMap::iterator iter = recordMap.find(recordName);
-        if(iter!=recordMap.end()) {
-             unlock();
-             return false;
-        }
-        record->start();
-        recordMap.insert(PVRecordMap::value_type(recordName,record));
-        unlock();
-        return true;
-    } catch(...) {
-        unlock();
-        throw;
+    epicsGuard<epics::pvData::Mutex> guard(mutex);
+    if(isDestroyed) {
+        return false;
     }
+    string recordName = record->getRecordName();
+    PVRecordMap::iterator iter = recordMap.find(recordName);
+    if(iter!=recordMap.end()) {
+         return false;
+    }
+    record->start();
+    recordMap.insert(PVRecordMap::value_type(recordName,record));
+    return true;
 }
 
 bool PVDatabase::removeRecord(PVRecordPtr const & record)
 {
-    lock();
-    try {
-        if(isDestroyed) {
-            unlock();
-            return false;
-        }
-        string recordName = record->getRecordName();
-        PVRecordMap::iterator iter = recordMap.find(recordName);
-        if(iter!=recordMap.end())  {
-            PVRecordPtr pvRecord = (*iter).second;
-            recordMap.erase(iter);
-            if(pvRecord.get()!=NULL) pvRecord->destroy();
-            unlock();
-            return true;
-        }
-        unlock();
+    epicsGuard<epics::pvData::Mutex> guard(mutex);
+    if(isDestroyed) {
         return false;
-    } catch(...) {
-        unlock();
-        throw;
     }
+    string recordName = record->getRecordName();
+    PVRecordMap::iterator iter = recordMap.find(recordName);
+    if(iter!=recordMap.end())  {
+        PVRecordPtr pvRecord = (*iter).second;
+        recordMap.erase(iter);
+        if(pvRecord.get()!=NULL) pvRecord->destroy();
+        return true;
+    }
+    return false;
 }
 
 }}


### PR DESCRIPTION
As promised...

These objects provide exception-safe locking and unlocking, and remove the need for wrapping code that might throw inside a `try {...} catch { unlock(); }` block to ensure locks are properly released and/or re-taken when the call stack is unwound.

The epicsGuard template is similar to the Lock class in pvDataCPP, it takes a lock in its constructor and releases it again in its destructor. There is currently no equivalent in V4 for epicsGuardRelease though, which temporarily releases a lock while it exists and locks it again in its destructor. An epicsGuard can be created using any kind of object that has both lock() and unlock() methods (the Lock class can only take a Mutex). An epicsGuardRelease requires there to be an existing epicsGuard that already owns the lock; its constructor is passed a reference to the guard object, and provides protection that ensures the two work together properly.
