### PR TITLE
jenkins/cloudbees_build attempt to make vxWorks and RTEMS build

### DIFF
--- a/jenkins/cloudbees_build
+++ b/jenkins/cloudbees_build
@@ -34,7 +34,7 @@ cd ${STUFF}
 wget -nv https://openepics.ci.cloudbees.com/job/Base-${BASE}_Build/lastSuccessfulBuild/artifact/base-${BASE}.CB-dist.tar.gz
 wget -nv https://openepics.ci.cloudbees.com/job/pvDataCPP_${PVDATA_BRANCH}Build/BASE=${BASE},USE_MB=MB_NO/lastSuccessfulBuild/artifact/pvData.CB-dist.tar.gz
 wget -nv https://openepics.ci.cloudbees.com/job/pvAccessCPP_${PVACCESS_BRANCH}Build/BASE=${BASE},USE_MB=${USE_MB}/lastSuccessfulBuild/artifact/pvAccess.CB-dist.tar.gz
-wget -nv https://openepics.ci.cloudbees.com/job/pvaSrvCPP_${PVASRV_BRANCH}Build/BASE=${BASE},USE_MB=MB_NO/lastSuccessfulBuild/artifact/pvaSrv.CB-dist.tar.gz
+
 tar -xzf base-${BASE}.CB-dist.tar.gz
 tar -xzf pvData.CB-dist.tar.gz
 tar -xzf pvAccess.CB-dist.tar.gz
@@ -63,7 +63,7 @@ make distclean all
 ###########################################
 # Test
 
-make runtests
+#make runtests
 
 ###########################################
 # Create distribution

--- a/jenkins/cloudbees_build
+++ b/jenkins/cloudbees_build
@@ -63,7 +63,7 @@ make distclean all
 ###########################################
 # Test
 
-#make runtests
+make runtests
 
 ###########################################
 # Create distribution

--- a/src/Makefile
+++ b/src/Makefile
@@ -18,5 +18,9 @@ LIBRARY += pvDatabase
 pvDatabase_LIBS += pvAccess pvData Com
 pvDatabase_LIBS += $(EPICS_BASE_IOC_LIBS)
 
+# shared library ABI version.
+SHRLIB_VERSION ?= 4.2
+
+
 include $(TOP)/configure/RULES
 

--- a/src/pv/pvDatabase.h
+++ b/src/pv/pvDatabase.h
@@ -529,9 +529,3 @@ private:
 
 #endif  /* PVDATABASE_H */
 
-/** @page Overview Documentation
- *
- * <a href = "../pvDatabaseCPP.html">pvDatabase.html</a>
- *
- */
-


### PR DESCRIPTION
src/pvAccess/channelLocal.cpp // trap exceptions and turn into Status.
All the methods called by the client that access a record now trap exceptions and turn them into
a Status that is returned to the client callback.
Before clients (for example pvget) failed with timout.
Now a bad status is returned.

src/pv/pvDatabase.h // attempt to make doc build
This had an doc comment that is not needed since Doxyfile does what it required.

jenkins/cloudbees_build

This  was changed to see if vxWorks, RTEMS, and windows now build.
make runtests
has been commented out.