### PR TITLE
for installing in include/pv follow  pvaClientCPP

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -20,8 +20,5 @@
 #   INSTALL_LOCATION here.
 #INSTALL_LOCATION=</path/name/to/install/top>
 
-INSTALL_INCLUDE = $(INSTALL_LOCATION)/include/pv
-USR_INCLUDES += -I $(INSTALL_LOCATION)/include
-
 -include $(TOP)/../CONFIG_SITE.local
 -include $(TOP)/configure/CONFIG_SITE.local

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -14,7 +14,7 @@
 # Set CHECK_RELEASE to NO to disable checking completely.
 # Set CHECK_RELEASE to WARN to perform consistency checking but
 #   continue building anyway if conflicts are found.
-#CHECK_RELEASE = YES
+CHECK_RELEASE = WARN
 
 # To install files into a location other than $(TOP) define
 #   INSTALL_LOCATION here.

--- a/documentation/TODO.html
+++ b/documentation/TODO.html
@@ -1,8 +1,0 @@
-<h1>TODO</h1>
-<h2>monitorPlugin</h2>
-<p>A debate is on-going about what semantics should be.</p>
-<h2>Must test record delete.</h2>
-<p>Must test removing a record from the PVDatabase while a pvAccess client
-is attached. Also why do both unlisten and detach exists?</p>
-<h2>create more regression tests</h2>
-<p>Currently only some simple tests exist. Most of the testing has been via the examples</p>

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,17 +3,19 @@
 TOP = ..
 include $(TOP)/configure/CONFIG
 
-INSTALL_INCLUDE = $(INSTALL_LOCATION)/include/pv
-USR_INCLUDES += -I$(INSTALL_LOCATION)/include
-
 PVDATABASE_SRC = $(TOP)/src
 
-include $(PVDATABASE_SRC)/pv/Makefile
+
+LIBRARY += pvDatabase
+
+INC += pv/channelProviderLocal.h
+INC += pv/pvDatabase.h
+INC += pv/traceRecord.h
+
 include $(PVDATABASE_SRC)/database/Makefile
 include $(PVDATABASE_SRC)/pvAccess/Makefile
 include $(PVDATABASE_SRC)/special/Makefile
 
-LIBRARY += pvDatabase
 
 pvDatabase_LIBS += pvAccess pvData Com
 pvDatabase_LIBS += $(EPICS_BASE_IOC_LIBS)

--- a/src/pv/Makefile
+++ b/src/pv/Makefile
@@ -1,5 +1,0 @@
-SRC_DIRS += $(PVDATABASE_SRC)/pv
-INC += pvDatabase.h
-INC += channelProviderLocal.h
-INC += traceRecord.h
-

--- a/test/rtemsTestHarness.c
+++ b/test/rtemsTestHarness.c
@@ -32,6 +32,6 @@ Init (rtems_task_argument ignored)
   osdTimeRegister();
   
   extern void pvDataAllTests(void);
-  pvDataAllTests();
+  pvDatabaseAllTests();
   epicsExit(0);
 }

--- a/test/rtemsTestHarness.c
+++ b/test/rtemsTestHarness.c
@@ -31,7 +31,6 @@ Init (rtems_task_argument ignored)
   }
   osdTimeRegister();
   
-  extern void pvDataAllTests(void);
   pvDatabaseAllTests();
   epicsExit(0);
 }

--- a/test/src/powerSupply.h
+++ b/test/src/powerSupply.h
@@ -37,7 +37,7 @@ namespace epics { namespace pvDatabase {
 class PowerSupply;
 typedef std::tr1::shared_ptr<PowerSupply> PowerSupplyPtr;
 
-class epicsShareClass PowerSupply :
+class PowerSupply :
     public PVRecord
 {
 public:

--- a/test/src/testExampleRecord.cpp
+++ b/test/src/testExampleRecord.cpp
@@ -30,6 +30,7 @@
 #include <pv/standardPVField.h>
 #include <pv/pvData.h>
 #include <pv/pvAccess.h>
+#define epicsExportSharedSymbols
 #include "powerSupply.h"
 
 #include <epicsExport.h>

--- a/test/src/testPVCopy.cpp
+++ b/test/src/testPVCopy.cpp
@@ -29,6 +29,7 @@
 #include <pv/standardPVField.h>
 #include <pv/channelProviderLocal.h>
 #include <pv/convert.h>
+#define epicsExportSharedSymbols
 #include "powerSupply.h"
 
 

--- a/test/src/testPVRecord.cpp
+++ b/test/src/testPVRecord.cpp
@@ -29,6 +29,7 @@
 #include <pv/standardPVField.h>
 #include <pv/pvData.h>
 #include <pv/pvCopy.h>
+#define epicsExportSharedSymbols
 #include "powerSupply.h"
 
 


### PR DESCRIPTION
Follow the way Michael installed header files from pvaClientCPP.

Note that
INSTALL_INCLUDE = $(INSTALL_LOCATION)/include/pv
No longer appears in any Makefile or config file.

