### PR TITLE
remove unused ContextLocal

### DIFF
--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -18,7 +18,6 @@
 #
 # Create a file RELEASE.local pointing to your PVASRV, PVACCESS,
 # PVDATA, PVCOMMON and EPICS_BASE build directories, e.g.
-#   PVASRV   = /path/to/epics/pvaSrvCPP
 #   PVACCESS = /path/to/epics/pvAccessCPP
 #   PVDATA   = /path/to/epics/pvDataCPP
 #   PVCOMMON = /path/to/epics/pvCommonCPP

--- a/src/pv/channelProviderLocal.h
+++ b/src/pv/channelProviderLocal.h
@@ -400,44 +400,5 @@ private:
     epics::pvData::Mutex mutex;
 };
 
-
-/**
- * @brief A pvAccess server context that provides
- * remote access to a local channel providers (i.e. pvDatabase records).
- */
-class epicsShareClass ContextLocal
-{
-
-public:
-    POINTER_DEFINITIONS(ContextLocal);
-
-    static shared_pointer create();
-
-    /**
-     * Start the context thread.
-     * After this is called clients can connect to the server.
-     * @param waitForExit In true then waitForExit() method is called after the server is started.
-     */
-    void start(bool waitForExit = false);
-
-    /**
-     * Waits for "exit" to be entered on standard input and calls destroy() before returning.
-     */
-    void waitForExit();
-
-    /**
-     * This destroys the context.
-     * All clients will be disconnected.
-     */
-    void destroy();
-
-private:
-    ContextLocal();
-
-    ChannelProviderLocalPtr m_channelProvider;
-    epics::pvAccess::ServerContext::shared_pointer m_context;
-};
-
-
 }}
 #endif  /* CHANNELPROVIDERLOCAL_H */

--- a/src/pvAccess/channelProviderLocal.cpp
+++ b/src/pvAccess/channelProviderLocal.cpp
@@ -172,47 +172,4 @@ Channel::shared_pointer ChannelProviderLocal::createChannel(
     return Channel::shared_pointer();
 }
 
-
-ContextLocal::shared_pointer ContextLocal::create()
-{
-    return ContextLocal::shared_pointer(new ContextLocal());
-}
-
-void ContextLocal::start(bool _waitForExit)
-{
-    m_context = startPVAServer(
-            PVACCESS_ALL_PROVIDERS,
-            0,
-            true,
-            true);
-
-    if (_waitForExit)
-        waitForExit();
-}
-
-void ContextLocal::waitForExit()
-{
-    while (true)
-    {
-        std::cout << "Type 'exit' to stop: ";
-        std::string input;
-        std::cin >> input;
-        if (input == "exit")
-            break;
-    }
-
-    destroy();
-}
-
-void ContextLocal::destroy()
-{
-    if (m_context)
-        m_context->destroy();
-}
-
-ContextLocal::ContextLocal()
-{
-     m_channelProvider = getChannelProviderLocal();
-}
-
 }}


### PR DESCRIPTION
ContextLocal is not needed since pvAccessCPP implements ServerContext.

When pvAccessJava also implements ServerContext than ContextLocal can also be removed from pvDatabaseJava.