### PR TITLE
Support for additional Windows targets

### DIFF
--- a/src/pv/channelProviderLocal.h
+++ b/src/pv/channelProviderLocal.h
@@ -55,7 +55,7 @@ typedef std::tr1::shared_ptr<ChannelProviderLocal> ChannelProviderLocalPtr;
 class ChannelLocal;
 typedef std::tr1::shared_ptr<ChannelLocal> ChannelLocalPtr;
 
-epicsShareExtern MonitorFactoryPtr getMonitorFactory();
+epicsShareFunc MonitorFactoryPtr getMonitorFactory();
 
 /**
  * @brief MonitorFactory
@@ -92,13 +92,13 @@ public:
 private:
     MonitorFactory();
     friend class MonitorLocal;
-    friend MonitorFactoryPtr getMonitorFactory();
+    friend epicsShareFunc MonitorFactoryPtr getMonitorFactory();
     bool isDestroyed;
     epics::pvData::Mutex mutex;
 };
 
 
-epicsShareExtern ChannelProviderLocalPtr getChannelProviderLocal();
+epicsShareFunc ChannelProviderLocalPtr getChannelProviderLocal();
 
 /**
  * @brief ChannelProvider for PVDatabase.
@@ -186,7 +186,7 @@ private:
         return shared_from_this();
     }
     ChannelProviderLocal();
-    friend ChannelProviderLocalPtr getChannelProviderLocal();
+    friend epicsShareFunc ChannelProviderLocalPtr getChannelProviderLocal();
     PVDatabasePtr pvDatabase;
     epics::pvData::Mutex mutex;
     bool beingDestroyed;

--- a/src/pv/pvDatabase.h
+++ b/src/pv/pvDatabase.h
@@ -266,7 +266,7 @@ private:
     PVListenerWPtr pvListener;
 };
 
-epicsShareExtern std::ostream& operator<<(std::ostream& o, const PVRecord& record);
+epicsShareFunc std::ostream& operator<<(std::ostream& o, const PVRecord& record);
 
 /**
  * @brief Interface for a field of a record.

--- a/test/src/powerSupply.h
+++ b/test/src/powerSupply.h
@@ -30,7 +30,7 @@
 
 #include <shareLib.h>
 
-//epicsShareExtern epics::pvData::PVStructurePtr createPowerSupply();
+//epicsShareFunc epics::pvData::PVStructurePtr createPowerSupply();
 
 namespace epics { namespace pvDatabase { 
 


### PR DESCRIPTION
These changes allow pvAccessCPP to be built for the Cygwin and MinGW targets, including cross-compiling for MinGW on Linux.