### PR TITLE
use correct name in MAIN

### DIFF
--- a/test/src/testLocalProvider.cpp
+++ b/test/src/testLocalProvider.cpp
@@ -1,4 +1,4 @@
-/*testExampleServerMain.cpp */
+/*testLocalProviderMain.cpp */
 /**
  * Copyright - See the COPYRIGHT that is included with this distribution.
  * EPICS pvData is distributed subject to a Software License Agreement found
@@ -73,7 +73,7 @@ void test()
     channelProvider->destroy();
 }
 
-MAIN(testExampleServer)
+MAIN(testLocalProvider)
 {
     testPlan(3);
     test();

--- a/test/src/testPVAServer.cpp
+++ b/test/src/testPVAServer.cpp
@@ -1,4 +1,4 @@
-/*testExampleServerMain.cpp */
+/*testPVAServerMain.cpp */
 /**
  * Copyright - See the COPYRIGHT that is included with this distribution.
  * EPICS pvData is distributed subject to a Software License Agreement found
@@ -70,7 +70,7 @@ void test()
     ctx->destroy();
 }
 
-MAIN(testExampleServer)
+MAIN(testPVAServer)
 {
     testPlan(1);
     test();


### PR DESCRIPTION
Hopefully this will allow rtems and vxWorks to build successfully