### PR TITLE
monitor change to support filter plugin support

### DIFF
--- a/src/pvAccess/monitorFactory.cpp
+++ b/src/pvAccess/monitorFactory.cpp
@@ -204,9 +204,10 @@ void MonitorLocal::releaseActiveElement()
     {
         Lock xx(queueMutex);
         if(state!=active) return;
+        pvCopy->updateCopyFromBitSet(activeElement->pvStructurePtr,activeElement->changedBitSet);
+        if(activeElement->changedBitSet->nextSetBit(0)<0) return;
         MonitorElementPtr newActive = queue->getFree();
         if(!newActive) return;
-        pvCopy->updateCopyFromBitSet(activeElement->pvStructurePtr,activeElement->changedBitSet);
         BitSetUtil::compress(activeElement->changedBitSet,activeElement->pvStructurePtr);
         BitSetUtil::compress(activeElement->overrunBitSet,activeElement->pvStructurePtr);
         queue->setUsed(activeElement);


### PR DESCRIPTION
Filter plugins are now supported by copy facility from pvData.
This requires a change to how pvDatabase implements monitors.