### PR TITLE
Fix master build

### DIFF
--- a/src/pv/pvDatabase.h
+++ b/src/pv/pvDatabase.h
@@ -112,10 +112,10 @@ public:
      * @param pvRequest The request PVStructure 
      * @return The corresponding service
      */
-    virtual epics::pvAccess::Service::shared_pointer getService(
+    virtual epics::pvAccess::RPCServiceAsync::shared_pointer getService(
         epics::pvData::PVStructurePtr const & pvRequest)
     {
-        return epics::pvAccess::Service::shared_pointer();
+        return epics::pvAccess::RPCServiceAsync::shared_pointer();
     }
     /**
      * @brief Creates a <b>soft</b> record. 

--- a/src/pvAccess/channelLocal.cpp
+++ b/src/pvAccess/channelLocal.cpp
@@ -691,7 +691,7 @@ public:
     ChannelRPCLocal(
         ChannelLocalPtr const & channelLocal,
         ChannelRPCRequester::shared_pointer const & channelRPCRequester,
-        Service::shared_pointer const & service,
+        RPCServiceAsync::shared_pointer const & service,
         PVRecordPtr const & pvRecord) :
         channelLocal(channelLocal),
         channelRPCRequester(channelRPCRequester),
@@ -752,7 +752,7 @@ private:
 
     ChannelLocalPtr channelLocal;
     ChannelRPCRequester::weak_pointer channelRPCRequester;
-    Service::shared_pointer service;
+    RPCServiceAsync::shared_pointer service;
     PVRecordPtr pvRecord;
     AtomicBoolean isLastRequest;
 };
@@ -763,7 +763,7 @@ ChannelRPCLocalPtr ChannelRPCLocal::create(
     PVStructurePtr const & pvRequest,
     PVRecordPtr const &pvRecord)
 {
-    Service::shared_pointer service = pvRecord->getService(pvRequest);
+    RPCServiceAsync::shared_pointer service = pvRecord->getService(pvRequest);
     if (!service)
     {
         Status status(Status::STATUSTYPE_ERROR,

--- a/test/src/testPVAServer.cpp
+++ b/test/src/testPVAServer.cpp
@@ -67,7 +67,6 @@ static void test()
     ServerContext::shared_pointer ctx =
         startPVAServer("local",0,true,true);
     testOk1(ctx.get()!=0);
-    ctx->destroy();
 }
 
 MAIN(testPVAServer)


### PR DESCRIPTION
Hi Marty,

Please double-check these changes and merge this PR ASAP, they are needed to fix the builds of pvDatabaseCPP and EPICS 7. @mdavidsaver applied the deprecation policy to pvAccessCPP and removed some previously-deprecated methods which your code was still using (although the `Service` typedef hadn't been generating any warning messages, despite having the `EPICS_DEPRECATED` marker on it).

Thanks,

- Andrew