### PR TITLE
PVCOPY::updateMaster put to fields that did not change

### DIFF
--- a/src/copy/pv/pvStructureCopy.h
+++ b/src/copy/pv/pvStructureCopy.h
@@ -204,10 +204,16 @@ private:
         epics::pvData::PVFieldPtr const &pvCopy,
         CopyNodePtr const &node,
         epics::pvData::BitSetPtr const &bitSet);
-    void updateMaster(
-        epics::pvData::PVFieldPtr const &pvCopy,
-        CopyNodePtr const &node,
+    void updateMasterField(
+        CopyNodePtr const & node,
+        epics::pvData::PVFieldPtr const & pvCopy,
+        epics::pvData::PVFieldPtr const &pvMaster,
         epics::pvData::BitSetPtr const &bitSet);
+    void updateMasterCheckBitSet(
+        epics::pvData::PVStructurePtr const  &copyPVStructure,
+        epics::pvData::BitSetPtr const  &bitSet,
+        size_t nextSet);
+    CopyNodePtr getCopyNode(std::size_t fieldOffset);
 
     PVCopy(epics::pvData::PVStructurePtr const &pvMaster);
     bool init(epics::pvData::PVStructurePtr const &pvRequest);

--- a/src/copy/pvCopy.cpp
+++ b/src/copy/pvCopy.cpp
@@ -259,8 +259,6 @@ CopyNodePtr PVCopy::getCopyNode(std::size_t fieldOffset)
     if(fieldOffset==0) return headNode;
     CopyNodePtr node = headNode;
     while(true) {
-        size_t soff = node->structureOffset;
-        if(fieldOffset>=soff && fieldOffset<soff+node->nfields) return node;
         if(!node->isStructure) return node;
         CopyStructureNodePtr structNode = static_pointer_cast<CopyStructureNode>(node);
         CopyNodePtrArrayPtr nodes = structNode->nodes;


### PR DESCRIPTION
If a client via a channelPut or channelPutGet requests more fields than just fields it changes then those field also appear to be changed.

The result is that monitors are issued for fields that have not changed.
The pull request fixes the problem