### PR TITLE
remove new method for PVRecord

### DIFF
--- a/src/pv/pvDatabase.h
+++ b/src/pv/pvDatabase.h
@@ -102,6 +102,15 @@ public:
      */
     virtual void destroy() {}
     /**
+     *  @brief remove record from database.
+     *
+     * Remove the PVRecord. Release any resources used and 
+     *  get rid of listeners and requesters.
+     *  If derived class overrides this then it must call PVRecord::remove()
+     *  after it has destroyed any resorces it uses.
+     */
+    virtual void remove();
+    /**
      *  @brief Optional method for derived class.
      *
      * Return a service corresponding to the specified request PVStructure.

--- a/src/special/removeRecord.cpp
+++ b/src/special/removeRecord.cpp
@@ -65,7 +65,7 @@ void RemoveRecord::process()
         pvResult->put(name + " not found");
         return;
     }
-    pvRecord->destroy();
+    pvRecord->remove();
     pvResult->put("success");
 }
 


### PR DESCRIPTION
This is a fix for issue #44.
When the  destroy methods were made empty the one for PVRecord was also made empty
PVRecord now has a new method remove, which does what the previous PVRecord::destroy did.