### PR TITLE
Cleanup whitespace

### DIFF
--- a/example/createdestroy/createdestroy.cpp
+++ b/example/createdestroy/createdestroy.cpp
@@ -29,12 +29,12 @@ public:
     virtual void process (void);
 };
 
-std::shared_ptr<Record> Record::create (std::string const & name, std::shared_ptr<::epics::pvData::PVStructure> const & pvstruct) 
-{ 
-  std::shared_ptr<Record> pvrecord (new Record (name, pvstruct)); 
+std::shared_ptr<Record> Record::create (std::string const & name, std::shared_ptr<::epics::pvData::PVStructure> const & pvstruct)
+{
+  std::shared_ptr<Record> pvrecord (new Record (name, pvstruct));
   // Need to be explicitly called .. not part of the base constructor
   if(!pvrecord->init()) pvrecord.reset();
-  return pvrecord; 
+  return pvrecord;
 }
 
 void Record::process (void)
@@ -87,7 +87,7 @@ void MyMonitor::getData()
 }
 
 
-int main (int argc, char** argv) 
+int main (int argc, char** argv)
 {
   int verbose = 0;
   unsigned loopctr = 0;
@@ -115,9 +115,9 @@ int main (int argc, char** argv)
              std::cout << "-r call pvRecord->remove -d call master->removeRecord\n";
              std::cout << "default\n";
              std::cout << "-v " << verbose
-                  << " -a  false" 
+                  << " -a  false"
                   << " -d"
-                  << "\n";           
+                  << "\n";
               return 0;
           default:
               std::cerr<<"Unknown argument: "<<opt<<"\n";
@@ -127,10 +127,10 @@ int main (int argc, char** argv)
   if(!callRecord && !callDatabase) callDatabase = true;
   ::epics::pvDatabase::PVDatabasePtr master = epics::pvDatabase::PVDatabase::getMaster();
   ::epics::pvDatabase::ChannelProviderLocalPtr channelProvider = epics::pvDatabase::getChannelProviderLocal();
-  epics::pvAccess::ServerContext::shared_pointer context 
+  epics::pvAccess::ServerContext::shared_pointer context
       = epics::pvAccess::startPVAServer(epics::pvAccess::PVACCESS_ALL_PROVIDERS, 0, true, true);
   std::string startset("starting set of puts valuectr = ");
-  
+
   while (true) {
       loopctr++;
       std::string name = DEFAULT_RECORD_NAME + std::to_string(loopctr);
@@ -139,7 +139,7 @@ int main (int argc, char** argv)
       // Create record structure
       ::epics::pvData::FieldBuilderPtr builder = epics::pvData::getFieldCreate()->createFieldBuilder();
       builder->add("value", ::epics::pvData::pvULong);
-      std::shared_ptr<::epics::pvData::PVStructure> pvstruct 
+      std::shared_ptr<::epics::pvData::PVStructure> pvstruct
           = ::epics::pvData::getPVDataCreate()->createPVStructure(builder->createStructure());
       std::shared_ptr<Record> pvrecord = Record::create(std::string(name), pvstruct);
       master->addRecord(pvrecord);

--- a/src/copy/pvArrayPlugin.cpp
+++ b/src/copy/pvArrayPlugin.cpp
@@ -130,7 +130,7 @@ PVArrayFilterPtr PVArrayFilter::create(
     }
     PVArrayFilterPtr filter =
          PVArrayFilterPtr(
-             new PVArrayFilter(start,increment,end,masterField,masterArray)); 
+             new PVArrayFilter(start,increment,end,masterField,masterArray));
     return filter;
 }
 

--- a/src/copy/pvArrayPlugin.cpp
+++ b/src/copy/pvArrayPlugin.cpp
@@ -223,4 +223,3 @@ string PVArrayFilter::getName()
 }
 
 }}
-

--- a/src/copy/pvArrayPlugin.cpp
+++ b/src/copy/pvArrayPlugin.cpp
@@ -168,36 +168,36 @@ bool PVArrayFilter::filter(const PVFieldPtr & pvField,const BitSetPtr & bitSet,b
     long end = this->end;
     long no_elements = masterArray->getLength();
     if(start<0) {
-    	start = no_elements+start;
-    	if(start<0) start = 0;
+        start = no_elements+start;
+        if(start<0) start = 0;
     }
     if (end < 0) {
-    	end = no_elements + end;
-    	if (end < 0) end = 0;
+        end = no_elements + end;
+        if (end < 0) end = 0;
 
     }
     if(toCopy) {
-    	if (end >= no_elements) end = no_elements - 1;
-    	if (end - start >= 0) len = 1 + (end - start) / increment;
-    	if(len<=0 || start>=no_elements) {
-    		copyArray->setLength(0);
-    		return true;
-    	}
-    	long indfrom = start;
-    	long indto = 0;
-    	copyArray->setCapacity(len);
-    	if(increment==1) {
+        if (end >= no_elements) end = no_elements - 1;
+        if (end - start >= 0) len = 1 + (end - start) / increment;
+        if(len<=0 || start>=no_elements) {
+            copyArray->setLength(0);
+            return true;
+        }
+        long indfrom = start;
+        long indto = 0;
+        copyArray->setCapacity(len);
+        if(increment==1) {
             copy(*masterArray,indfrom,1,*copyArray,indto,1,len);
-    	} else {
-    	    for(long i=0; i<len; ++i) {
-    	        copy(*masterArray,indfrom,1,*copyArray,indto,1,1);
-    	        indfrom += increment;
-    	         indto += 1;
-    	    }
-    	}
-    	copyArray->setLength(len);
+        } else {
+            for(long i=0; i<len; ++i) {
+                copy(*masterArray,indfrom,1,*copyArray,indto,1,1);
+                indfrom += increment;
+                 indto += 1;
+            }
+        }
+        copyArray->setLength(len);
         bitSet->set(pvField->getFieldOffset());
-    	return true;
+        return true;
     }
     if (end - start >= 0) len = 1 + (end - start) / increment;
     if(len<=0) return true;
@@ -205,13 +205,13 @@ bool PVArrayFilter::filter(const PVFieldPtr & pvField,const BitSetPtr & bitSet,b
     long indfrom = 0;
     long indto = start;
     if(increment==1) {
-    	copy(*copyArray,indfrom,1,*masterArray,indto,1,len);
+        copy(*copyArray,indfrom,1,*masterArray,indto,1,len);
     } else {
-    	for(long i=0; i<len; ++i) {
-    	    copy(*copyArray,indfrom,1,*masterArray,indto,1,1);
-    	    indfrom += 1;
-    	     indto += increment;
-    	}
+        for(long i=0; i<len; ++i) {
+            copy(*copyArray,indfrom,1,*masterArray,indto,1,1);
+            indfrom += 1;
+             indto += increment;
+        }
     }
     if(isUnion) masterField->postPut();
     return true;
@@ -219,7 +219,7 @@ bool PVArrayFilter::filter(const PVFieldPtr & pvField,const BitSetPtr & bitSet,b
 
 string PVArrayFilter::getName()
 {
-	return name;
+    return name;
 }
 
 }}

--- a/src/copy/pvCopy.cpp
+++ b/src/copy/pvCopy.cpp
@@ -648,7 +648,7 @@ void PVCopy::traverseMasterInitPlugin(CopyNodePtr const & node)
 {
     PVFieldPtr pvField = node->masterPVField;
     PVStructurePtr pvOptions = node->options;
-    if(pvOptions) initPlugin(node,pvOptions,pvField);	
+    if(pvOptions) initPlugin(node,pvOptions,pvField);   
     if(!node->isStructure) return;
     CopyStructureNodePtr structureNode = static_pointer_cast<CopyStructureNode>(node);
     CopyNodePtrArrayPtr nodes = structureNode->nodes;
@@ -710,7 +710,7 @@ void PVCopy::setIgnore(CopyNodePtr const &node) {
          CopyNodePtrArrayPtr nodes = structureNode->nodes;
          for(size_t i=0; i<nodes->size(); ++i) {
             CopyNodePtr node = (*nodes)[i];
-            setIgnore(node);		}
+            setIgnore(node);        }
     } else {
         size_t num = node->masterPVField->getNumberFields();
         if(num>1) {

--- a/src/copy/pvCopy.cpp
+++ b/src/copy/pvCopy.cpp
@@ -29,7 +29,7 @@ using std::endl;
 using std::vector;
 using namespace epics::pvData;
 
-namespace epics { namespace pvCopy { 
+namespace epics { namespace pvCopy {
 
 /**
  * Convenience method for implementing dump.
@@ -60,19 +60,19 @@ struct CopyNode {
     PVStructurePtr options;
     vector<PVFilterPtr> pvFilters;
 };
-    
+
 static CopyNodePtr NULLCopyNode;
 
 typedef std::vector<CopyNodePtr> CopyNodePtrArray;
 typedef std::tr1::shared_ptr<CopyNodePtrArray> CopyNodePtrArrayPtr;
-    
+
 struct CopyStructureNode : public  CopyNode {
     CopyNodePtrArrayPtr nodes;
 };
 
 PVCopyPtr PVCopy::create(
-    PVStructurePtr const &pvMaster, 
-    PVStructurePtr const &pvRequest, 
+    PVStructurePtr const &pvMaster,
+    PVStructurePtr const &pvRequest,
     string const & structureName)
 {
     PVStructurePtr pvStructure(pvRequest);
@@ -114,7 +114,7 @@ PVStructurePtr PVCopy::createPVStructure()
         cacheInitStructure.reset();
         return save;
     }
-    PVStructurePtr pvStructure = 
+    PVStructurePtr pvStructure =
         getPVDataCreate()->createPVStructure(structure);
     return pvStructure;
 }
@@ -296,7 +296,7 @@ void PVCopy::updateMaster(
         bitSet->clear(nextSet);
     }
 }
- 
+
 PVStructurePtr PVCopy::getOptions(std::size_t fieldOffset)
 {
     if(fieldOffset==0) return headNode->options;
@@ -414,7 +414,7 @@ void PVCopy::updateCopyFromBitSet(
     size_t offset = structureNode->structureOffset;
     size_t nextSet = bitSet->nextSetBit(offset);
     if(nextSet==string::npos) return;
-    if(offset>=pvCopy->getNextFieldOffset()) return;  
+    if(offset>=pvCopy->getNextFieldOffset()) return;
     PVStructurePtr pvCopyStructure = static_pointer_cast<PVStructure>(pvCopy);
     PVFieldPtrArray const & pvCopyFields = pvCopyStructure->getPVFields();
     for(size_t i=0; i<pvCopyFields.size(); ++i) {
@@ -529,9 +529,9 @@ CopyNodePtr PVCopy::createStructureNodes(
     for(size_t i=0; i<number; i++) {
         PVFieldPtr copyPVField = copyPVFields[i];
         string fieldName = copyPVField->getFieldName();
-        PVStructurePtr requestPVStructure = 
+        PVStructurePtr requestPVStructure =
              pvFromRequest->getSubField<PVStructure>(fieldName);
-        PVStructurePtr pvSubFieldOptions = 
+        PVStructurePtr pvSubFieldOptions =
             requestPVStructure->getSubField<PVStructure>("_options");
         PVFieldPtr pvMasterField = pvMasterStructure->getSubField(fieldName);
         if(!pvMasterField) {
@@ -641,14 +641,14 @@ void PVCopy::initPlugin(
 
 void PVCopy::traverseMasterInitPlugin()
 {
-    traverseMasterInitPlugin(headNode); 
+    traverseMasterInitPlugin(headNode);
 }
 
 void PVCopy::traverseMasterInitPlugin(CopyNodePtr const & node)
 {
     PVFieldPtr pvField = node->masterPVField;
     PVStructurePtr pvOptions = node->options;
-    if(pvOptions) initPlugin(node,pvOptions,pvField);   
+    if(pvOptions) initPlugin(node,pvOptions,pvField);
     if(!node->isStructure) return;
     CopyStructureNodePtr structureNode = static_pointer_cast<CopyStructureNode>(node);
     CopyNodePtrArrayPtr nodes = structureNode->nodes;
@@ -667,7 +667,7 @@ CopyNodePtr PVCopy::getCopyOffset(
         CopyNodePtr node = (*nodes)[i];
         if(!node->isStructure) {
             size_t off = node->masterPVField->getFieldOffset();
-            size_t nextOffset = node->masterPVField->getNextFieldOffset(); 
+            size_t nextOffset = node->masterPVField->getNextFieldOffset();
             if(offset>= off && offset<nextOffset) return node;
         } else {
             CopyStructureNodePtr subNode =

--- a/src/copy/pvDeadbandPlugin.cpp
+++ b/src/copy/pvDeadbandPlugin.cpp
@@ -82,7 +82,7 @@ PVDeadbandFilterPtr PVDeadbandFilter::create(
     PVDeadbandFilterPtr filter =
          PVDeadbandFilterPtr(
              new PVDeadbandFilter(
-                 absolute,deadband,static_pointer_cast<PVScalar>(master))); 
+                 absolute,deadband,static_pointer_cast<PVScalar>(master)));
     return filter;
 }
 
@@ -91,7 +91,7 @@ PVDeadbandFilter::PVDeadbandFilter(bool absolute,double deadband,PVScalarPtr con
   deadband(deadband),
   master(master),
   firstTime(true),
-  lastReportedValue(0.0) 
+  lastReportedValue(0.0)
 {
 }
 

--- a/src/copy/pvDeadbandPlugin.cpp
+++ b/src/copy/pvDeadbandPlugin.cpp
@@ -128,7 +128,7 @@ bool PVDeadbandFilter::filter(const PVFieldPtr & pvCopy,const BitSetPtr & bitSet
 
 string PVDeadbandFilter::getName()
 {
-	return name;
+    return name;
 }
 
 }}

--- a/src/copy/pvDeadbandPlugin.cpp
+++ b/src/copy/pvDeadbandPlugin.cpp
@@ -132,4 +132,3 @@ string PVDeadbandFilter::getName()
 }
 
 }}
-

--- a/src/copy/pvPlugin.cpp
+++ b/src/copy/pvPlugin.cpp
@@ -38,4 +38,3 @@ PVPluginPtr PVPluginRegistry::find(const std::string & name)
 }
 
 }}
-

--- a/src/copy/pvPlugin.cpp
+++ b/src/copy/pvPlugin.cpp
@@ -14,7 +14,7 @@
 
 using namespace epics::pvData;
 
-namespace epics { namespace pvCopy{ 
+namespace epics { namespace pvCopy{
 
 typedef std::map<std::string,PVPluginPtr> PVPluginMap;
 

--- a/src/copy/pvTimestampPlugin.cpp
+++ b/src/copy/pvTimestampPlugin.cpp
@@ -89,7 +89,7 @@ PVTimestampFilter::PVTimestampFilter(bool current,bool copy,PVFieldPtr const & m
 
 bool PVTimestampFilter::filter(const PVFieldPtr & pvCopy,const BitSetPtr & bitSet,bool toCopy)
 {
-    if(current) {	
+    if(current) {   
         timeStamp.getCurrent();
         if(toCopy) {
             if(!pvTimeStamp.attach(pvCopy)) return false;
@@ -100,7 +100,7 @@ bool PVTimestampFilter::filter(const PVFieldPtr & pvCopy,const BitSetPtr & bitSe
         bitSet->set(pvCopy->getFieldOffset());
         return true;
      }
-     if(copy) {	
+     if(copy) { 
         if(toCopy) {
             if(!pvTimeStamp.attach(master)) return false;
             pvTimeStamp.get(timeStamp);
@@ -120,7 +120,7 @@ bool PVTimestampFilter::filter(const PVFieldPtr & pvCopy,const BitSetPtr & bitSe
 
 string PVTimestampFilter::getName()
 {
-	return name;
+    return name;
 }
 
 }}

--- a/src/copy/pvTimestampPlugin.cpp
+++ b/src/copy/pvTimestampPlugin.cpp
@@ -89,7 +89,7 @@ PVTimestampFilter::PVTimestampFilter(bool current,bool copy,PVFieldPtr const & m
 
 bool PVTimestampFilter::filter(const PVFieldPtr & pvCopy,const BitSetPtr & bitSet,bool toCopy)
 {
-    if(current) {   
+    if(current) {
         timeStamp.getCurrent();
         if(toCopy) {
             if(!pvTimeStamp.attach(pvCopy)) return false;
@@ -100,7 +100,7 @@ bool PVTimestampFilter::filter(const PVFieldPtr & pvCopy,const BitSetPtr & bitSe
         bitSet->set(pvCopy->getFieldOffset());
         return true;
      }
-     if(copy) { 
+     if(copy) {
         if(toCopy) {
             if(!pvTimeStamp.attach(master)) return false;
             pvTimeStamp.get(timeStamp);

--- a/src/copy/pvTimestampPlugin.cpp
+++ b/src/copy/pvTimestampPlugin.cpp
@@ -124,4 +124,3 @@ string PVTimestampFilter::getName()
 }
 
 }}
-

--- a/src/database/pvDatabase.cpp
+++ b/src/database/pvDatabase.cpp
@@ -44,7 +44,7 @@ PVDatabasePtr PVDatabase::getMaster()
         PVArrayPlugin::create();
         PVTimestampPlugin::create();
         PVDeadbandPlugin::create();
-    }    
+    }
     return pvDatabaseMaster;
 }
 

--- a/src/database/pvRecord.cpp
+++ b/src/database/pvRecord.cpp
@@ -67,7 +67,7 @@ PVRecord::~PVRecord()
 
 void PVRecord::unlistenClients()
 {
-    epicsGuard<epics::pvData::Mutex> guard(mutex);   
+    epicsGuard<epics::pvData::Mutex> guard(mutex);
     for(std::list<PVListenerWPtr>::iterator iter = pvListenerList.begin();
          iter!=pvListenerList.end();
          iter++ )
@@ -104,7 +104,7 @@ void PVRecord::remove()
     epicsGuard<epics::pvData::Mutex> guard(mutex);
     PVDatabasePtr pvDatabase(PVDatabase::getMaster());
     if(pvDatabase) pvDatabase->removeFromMap(shared_from_this());
-    pvTimeStamp.detach();     
+    pvTimeStamp.detach();
 }
 
 void PVRecord::initPVRecord()
@@ -248,7 +248,7 @@ void PVRecord::nextMasterPVField(PVFieldPtr const & pvField)
      PVRecordFieldPtr pvRecordField = findPVRecordField(pvField);
      PVListenerPtr listener = pvListener.lock();
      if(!listener.get()) return;
-     if(isAddListener) {         
+     if(isAddListener) {
          pvRecordField->addListener(listener);
      } else {
          pvRecordField->removeListener(listener);
@@ -377,7 +377,7 @@ bool PVRecordField::addListener(PVListenerPtr const & pvListener)
 
 void PVRecordField::removeListener(PVListenerPtr const & pvListener)
 {
-    PVRecordPtr pvRecord(this->pvRecord.lock());   
+    PVRecordPtr pvRecord(this->pvRecord.lock());
     if(pvRecord && pvRecord->getTraceLevel()>1) {
          cout << "PVRecordField::removeListener() " << getFullName() << endl;
     }
@@ -419,7 +419,7 @@ void PVRecordField::postSubField()
 {
     callListener();
     if(isStructure) {
-        PVRecordStructurePtr pvrs = 
+        PVRecordStructurePtr pvrs =
             static_pointer_cast<PVRecordStructure>(shared_from_this());
         PVRecordFieldPtrArrayPtr pvRecordFields = pvrs->getPVRecordFields();
         PVRecordFieldPtrArray::iterator iter;
@@ -459,7 +459,7 @@ void PVRecordStructure::init()
     PVRecordStructurePtr self =
         static_pointer_cast<PVRecordStructure>(shared_from_this());
     PVRecordPtr pvRecord = getPVRecord();
-    for(size_t i=0; i<numFields; i++) {    
+    for(size_t i=0; i<numFields; i++) {
         PVFieldPtr pvField = pvFields[i];
         if(pvField->getField()->getType()==structure) {
              PVStructurePtr xxx = static_pointer_cast<PVStructure>(pvField);

--- a/src/pv/addRecord.h
+++ b/src/pv/addRecord.h
@@ -15,7 +15,7 @@
 
 #include <shareLib.h>
 
-namespace epics { namespace pvDatabase { 
+namespace epics { namespace pvDatabase {
 
 
 class AddRecord;

--- a/src/pv/channelProviderLocal.h
+++ b/src/pv/channelProviderLocal.h
@@ -28,7 +28,7 @@
 
 #include <shareLib.h>
 
-namespace epics { namespace pvDatabase { 
+namespace epics { namespace pvDatabase {
 
 class ChannelProviderLocal;
 typedef std::tr1::shared_ptr<ChannelProviderLocal> ChannelProviderLocalPtr;
@@ -93,7 +93,7 @@ public:
     virtual epics::pvAccess::ChannelFind::shared_pointer channelFind(
         std::string const &channelName,
         epics::pvAccess::ChannelFindRequester::shared_pointer const & channelFindRequester);
-    /** 
+    /**
      * @brief Calls method channelListRequester::channelListResult.
      *
      * This provides the caller with a list of the record names on the PVDatabase.
@@ -101,7 +101,7 @@ public:
      * @param channelListRequester The client callback.
      * @return shared pointer to ChannelFind.
      * The interface for SyncChannelFind is defined by pvAccessCPP.
-     */ 
+     */
     virtual epics::pvAccess::ChannelFind::shared_pointer channelList(
         epics::pvAccess::ChannelListRequester::shared_pointer const & channelListRequester);
     /**
@@ -186,28 +186,28 @@ public:
         epics::pvAccess::ChannelRequester::shared_pointer const & requester,
         PVRecordPtr const & pvRecord
     );
-    /** 
+    /**
      * @brief Destructor
      */
     virtual ~ChannelLocal();
-    /** 
+    /**
      * @brief DEPRECATED
      *
      */
     virtual void destroy() {};
-    /** 
+    /**
      * @brief Detach from the record.
      *
      * This is called when a record is being removed from the database.
      * @param pvRecord The record being removed.
      */
     virtual void detach(PVRecordPtr const &pvRecord);
-    /** 
+    /**
      * @brief Get the requester name.
      * @return returns the name of the channel requester.
      */
     virtual std::string getRequesterName();
-    /** 
+    /**
      * @brief Passes the message to the channel requester.
      * @param message The message.
      * @param messageType The message type.
@@ -215,37 +215,37 @@ public:
     virtual void message(
         std::string const & message,
         epics::pvData::MessageType messageType);
-    /** 
+    /**
      * @brief Get the channel provider
      * @return The provider.
      */
     virtual epics::pvAccess::ChannelProvider::shared_pointer getProvider();
-    /** 
+    /**
      * @brief Get the remote address
      * @return <b>local</b>
      */
     virtual std::string getRemoteAddress();
-    /** 
+    /**
      * Get the connection state.
      * @return Channel::CONNECTED.
      */
     virtual epics::pvAccess::Channel::ConnectionState getConnectionState();
-    /** 
+    /**
      * @brief Get the channel name.
      * @return the record name.
      */
     virtual std::string getChannelName();
-    /** 
+    /**
      * @brief Get the channel requester
      * @return The channel requester.
      */
     virtual epics::pvAccess::ChannelRequester::shared_pointer getChannelRequester();
-    /** 
+    /**
      * @brief Is the channel connected?
      * @return true.
      */
     virtual bool isConnected();
-    /** 
+    /**
      * @brief Get the introspection interface for subField.
      *
      * The introspection interface is given via GetFieldRequester::getDone.
@@ -257,14 +257,14 @@ public:
     virtual void getField(
         epics::pvAccess::GetFieldRequester::shared_pointer const &requester,
         std::string const & subField);
-    /** 
+    /**
      * Get the access rights for the record.
      * This throws an exception because it is assumed that access rights are
      * handled by a higher level.
      */
     virtual epics::pvAccess::AccessRights getAccessRights(
         epics::pvData::PVField::shared_pointer const &pvField);
-    /** 
+    /**
      * @brief Create a channelProcess.
      *
      * @param requester The client callback.
@@ -275,9 +275,9 @@ public:
     virtual epics::pvAccess::ChannelProcess::shared_pointer createChannelProcess(
         epics::pvAccess::ChannelProcessRequester::shared_pointer const &requester,
         epics::pvData::PVStructurePtr const &pvRequest);
-    /** 
+    /**
      * @brief Create a channelGet.
-     * 
+     *
      * @param requester The client callback.
      * @param pvRequest The options specified by the client.
      * @return A shared pointer to the newly created implementation.
@@ -286,7 +286,7 @@ public:
     virtual epics::pvAccess::ChannelGet::shared_pointer createChannelGet(
         epics::pvAccess::ChannelGetRequester::shared_pointer const &requester,
         epics::pvData::PVStructurePtr const &pvRequest);
-    /** 
+    /**
      * @brief Create a channelPut.
      *
      * @param requester The client callback.
@@ -297,9 +297,9 @@ public:
     virtual epics::pvAccess::ChannelPut::shared_pointer createChannelPut(
         epics::pvAccess::ChannelPutRequester::shared_pointer const &requester,
         epics::pvData::PVStructurePtr const &pvRequest);
-    /** 
+    /**
      * @brief Create a channelPutGet.
-     * 
+     *
      * @param requester The client callback.
      * @param pvRequest The options specified by the client.
      * @return A shared pointer to the newly created implementation.
@@ -308,7 +308,7 @@ public:
     virtual epics::pvAccess::ChannelPutGet::shared_pointer createChannelPutGet(
         epics::pvAccess::ChannelPutGetRequester::shared_pointer const &requester,
         epics::pvData::PVStructurePtr const &pvRequest);
-    /** 
+    /**
      * @brief Create a channelRPC.
      *
      * The PVRecord must implement <b>getService</b> or an empty shared pointer is returned.
@@ -319,9 +319,9 @@ public:
     virtual epics::pvAccess::ChannelRPC::shared_pointer createChannelRPC(
         epics::pvAccess::ChannelRPCRequester::shared_pointer const &requester,
         epics::pvData::PVStructurePtr const &pvRequest);
-    /** 
+    /**
      * @brief Create a monitor.
-     * 
+     *
      * @param requester The client callback.
      * @param pvRequest The options specified by the client.
      * @return A shared pointer to the newly created implementation.
@@ -330,9 +330,9 @@ public:
     virtual epics::pvData::Monitor::shared_pointer createMonitor(
         epics::pvData::MonitorRequester::shared_pointer const &requester,
         epics::pvData::PVStructurePtr const &pvRequest);
-    /** 
+    /**
      * @brief Create a channelArray.
-     * 
+     *
      * @param requester The client callback.
      * @param pvRequest The options specified by the client.
      * @return A shared pointer to the newly created implementation.
@@ -341,13 +341,13 @@ public:
     virtual epics::pvAccess::ChannelArray::shared_pointer createChannelArray(
         epics::pvAccess::ChannelArrayRequester::shared_pointer const &requester,
         epics::pvData::PVStructurePtr const &pvRequest);
-    /** 
+    /**
      *  @brief calls printInfo(std::cout);
      */
     virtual void printInfo();
-    /** 
+    /**
      * @brief displays a message
-     * 
+     *
      * @param out the stream on which the message is displayed.
      */
     virtual void printInfo(std::ostream& out);

--- a/src/pv/controlSupport.h
+++ b/src/pv/controlSupport.h
@@ -87,4 +87,3 @@ private:
 }}
 
 #endif  /* CONTROLSUPPORT_H */
-

--- a/src/pv/controlSupport.h
+++ b/src/pv/controlSupport.h
@@ -16,7 +16,7 @@
 
 #include <shareLib.h>
 
-namespace epics { namespace pvDatabase { 
+namespace epics { namespace pvDatabase {
 
 class ControlSupport;
 typedef std::tr1::shared_ptr<ControlSupport> ControlSupportPtr;
@@ -57,20 +57,20 @@ public:
      * @return Returns true is any fields were modified; otherwise false.
      */
     virtual void reset();
-    /** 
+    /**
      * @brief create a ControlSupport
      *
      * @param pvRecord - The pvRecord to which the support is attached.
      * @return The new ControlSupport
      */
     static ControlSupportPtr create(PVRecordPtr const & pvRecord);
-    /** 
+    /**
      * @brief create a controlSupport required by ControlSupport
      *
      * @param scalarType The type for outputValue.
      * @return The controlField introspection structure.
      */
-    static epics::pvData::StructureConstPtr controlField(epics::pvData::ScalarType scalarType); 
+    static epics::pvData::StructureConstPtr controlField(epics::pvData::ScalarType scalarType);
 private:
     ControlSupport(PVRecordPtr const & pvRecord);
     PVRecordPtr pvRecord;

--- a/src/pv/processRecord.h
+++ b/src/pv/processRecord.h
@@ -18,7 +18,7 @@
 
 #include <shareLib.h>
 
-namespace epics { namespace pvDatabase { 
+namespace epics { namespace pvDatabase {
 
 typedef std::tr1::shared_ptr<epicsThread> EpicsThreadPtr;
 

--- a/src/pv/pvArrayPlugin.h
+++ b/src/pv/pvArrayPlugin.h
@@ -99,4 +99,3 @@ public:
 
 }}
 #endif  /* PVARRAYPLUGIN_H */
-

--- a/src/pv/pvDatabase.h
+++ b/src/pv/pvDatabase.h
@@ -16,7 +16,7 @@
 
 #include <shareLib.h>
 
-namespace epics { namespace pvDatabase { 
+namespace epics { namespace pvDatabase {
 
 class PVRecord;
 typedef std::tr1::shared_ptr<PVRecord> PVRecordPtr;
@@ -93,7 +93,7 @@ public:
     /**
      *  @brief remove record from database.
      *
-     * Remove the PVRecord. Release any resources used and 
+     * Remove the PVRecord. Release any resources used and
      *  get rid of listeners and requesters.
      *  If derived class overrides this then it must call PVRecord::remove()
      *  after it has destroyed any resorces it uses.
@@ -101,9 +101,9 @@ public:
     virtual void remove();
     /**
      *  @brief Optional method for derived class.
-     * 
+     *
      * Return a service corresponding to the specified request PVStructure.
-     * @param pvRequest The request PVStructure 
+     * @param pvRequest The request PVStructure
      * @return The corresponding service
      */
     virtual epics::pvAccess::RPCServiceAsync::shared_pointer getService(
@@ -112,7 +112,7 @@ public:
         return epics::pvAccess::RPCServiceAsync::shared_pointer();
     }
     /**
-     * @brief Creates a <b>soft</b> record. 
+     * @brief Creates a <b>soft</b> record.
      *
      * @param recordName The name of the record, which is also the channelName.
      * @param pvStructure The top level structure.
@@ -247,7 +247,7 @@ protected:
         epics::pvData::PVStructurePtr const & pvStructure);
     /**
      * @brief Initializes the base class.
-     * 
+     *
      * Must be called by derived classes.
      */
     void initPVRecord();
@@ -512,7 +512,7 @@ public:
     epics::pvData::PVStringArrayPtr getRecordNames();
 private:
     friend class PVRecord;
-    
+
     PVRecordWPtr removeFromMap(PVRecordPtr const & record);
     PVDatabase();
     void lock();

--- a/src/pv/pvDatabase.h
+++ b/src/pv/pvDatabase.h
@@ -525,4 +525,3 @@ private:
 }}
 
 #endif  /* PVDATABASE_H */
-

--- a/src/pv/pvDeadbandPlugin.h
+++ b/src/pv/pvDeadbandPlugin.h
@@ -100,4 +100,3 @@ public:
 
 }}
 #endif  /* PVDEADBANDPLUGIN_H */
-

--- a/src/pv/pvDeadbandPlugin.h
+++ b/src/pv/pvDeadbandPlugin.h
@@ -66,7 +66,7 @@ private:
     epics::pvData::PVScalarPtr master;
     bool firstTime;
     double lastReportedValue;
-    
+
 
     PVDeadbandFilter(bool absolute,double deadband,epics::pvData::PVScalarPtr const & master);
 public:

--- a/src/pv/pvPlugin.h
+++ b/src/pv/pvPlugin.h
@@ -16,7 +16,7 @@
 
 #include <shareLib.h>
 
-namespace epics { namespace pvCopy{ 
+namespace epics { namespace pvCopy{
 
 class PVPlugin;
 class PVFilter;
@@ -36,7 +36,7 @@ typedef std::map<std::string,PVPluginPtr> PVPluginMap;
  * PVCopy looks for plugins defined in pvRequest and calls the filter when a pvCopy is updated.
  * @author mrk
  * @since 2017.03.17
- * 
+ *
  * Interface for a filter plugin for PVCopy.
  *
  */

--- a/src/pv/pvStructureCopy.h
+++ b/src/pv/pvStructureCopy.h
@@ -18,7 +18,7 @@
 
 #include <shareLib.h>
 
-namespace epics { namespace pvCopy{ 
+namespace epics { namespace pvCopy{
 
 class PVCopyTraverseMasterCallback;
 typedef std::tr1::shared_ptr<PVCopyTraverseMasterCallback> PVCopyTraverseMasterCallbackPtr;
@@ -62,7 +62,7 @@ typedef std::tr1::shared_ptr<CopyStructureNode> CopyStructureNodePtr;
  * Class that manages one or more PVStructures that holds an arbitrary subset of the fields
  * in another PVStructure called master.
  */
-class epicsShareClass PVCopy : 
+class epicsShareClass PVCopy :
     public std::tr1::enable_shared_from_this<PVCopy>
 {
 public:
@@ -173,12 +173,12 @@ public:
      */
     std::string dump();
 private:
-    
+
     PVCopyPtr getPtrSelf()
     {
         return shared_from_this();
     }
-    
+
     epics::pvData::PVStructurePtr pvMaster;
     epics::pvData::StructureConstPtr structure;
     CopyNodePtr headNode;

--- a/src/pv/pvSupport.h
+++ b/src/pv/pvSupport.h
@@ -20,7 +20,7 @@
 
 #include <shareLib.h>
 
-namespace epics { namespace pvDatabase { 
+namespace epics { namespace pvDatabase {
 
 class PVSupport;
 typedef std::tr1::shared_ptr<PVSupport> PVSupportPtr;
@@ -29,7 +29,7 @@ typedef std::tr1::shared_ptr<PVSupport> PVSupportPtr;
  * @brief Base interface for a PVSupport.
  *
  */
-class epicsShareClass PVSupport 
+class epicsShareClass PVSupport
 {
 public:
     POINTER_DEFINITIONS(PVSupport);

--- a/src/pv/pvSupport.h
+++ b/src/pv/pvSupport.h
@@ -75,4 +75,3 @@ public:
 }}
 
 #endif  /* PVSUPPORT_H */
-

--- a/src/pv/pvTimestampPlugin.h
+++ b/src/pv/pvTimestampPlugin.h
@@ -98,4 +98,3 @@ public:
 
 }}
 #endif  /* PVTIMESTAMPPLUGIN_H */
-

--- a/src/pv/pvTimestampPlugin.h
+++ b/src/pv/pvTimestampPlugin.h
@@ -66,7 +66,7 @@ private:
     bool current;
     bool copy;
     epics::pvData::PVFieldPtr master;
-    
+
 
     PVTimestampFilter(bool current,bool copy,epics::pvData::PVFieldPtr const & pvField);
 public:

--- a/src/pv/removeRecord.h
+++ b/src/pv/removeRecord.h
@@ -15,7 +15,7 @@
 
 #include <shareLib.h>
 
-namespace epics { namespace pvDatabase { 
+namespace epics { namespace pvDatabase {
 
 
 class RemoveRecord;

--- a/src/pv/scalarAlarmSupport.h
+++ b/src/pv/scalarAlarmSupport.h
@@ -19,7 +19,7 @@
 
 #include <shareLib.h>
 
-namespace epics { namespace pvDatabase { 
+namespace epics { namespace pvDatabase {
 
 class ScalarAlarmSupport;
 typedef std::tr1::shared_ptr<ScalarAlarmSupport> ScalarAlarmSupportPtr;
@@ -61,19 +61,19 @@ public:
      *
      */
     virtual void reset();
-    /** 
+    /**
      * @brief create a ScalarAlarm
      *
      * @param pvRecord - The pvRecord to which the support is attached.
      * @return The new ScalarAlarm
      */
     static ScalarAlarmSupportPtr create(PVRecordPtr const & pvRecord);
-    /** 
+    /**
      * @brief create a scalarAlarm required by ScalarAlarm
      *
      * @return The scalarAlarmField introspection structure.
      */
-    static epics::pvData::StructureConstPtr scalarAlarmField(); 
+    static epics::pvData::StructureConstPtr scalarAlarmField();
 private:
 
     ScalarAlarmSupport(PVRecordPtr const & pvRecord);

--- a/src/pv/scalarAlarmSupport.h
+++ b/src/pv/scalarAlarmSupport.h
@@ -108,4 +108,3 @@ private:
 }}
 
 #endif  /* SCALARALARMSUPPORT_H */
-

--- a/src/pv/traceRecord.h
+++ b/src/pv/traceRecord.h
@@ -16,7 +16,7 @@
 #include <shareLib.h>
 
 
-namespace epics { namespace pvDatabase { 
+namespace epics { namespace pvDatabase {
 
 
 class TraceRecord;

--- a/src/pvAccess/channelLocal.cpp
+++ b/src/pvAccess/channelLocal.cpp
@@ -38,7 +38,7 @@ using std::cout;
 using std::endl;
 using std::string;
 
-namespace epics { namespace pvDatabase { 
+namespace epics { namespace pvDatabase {
 
 static StructureConstPtr nullStructure;
 
@@ -102,7 +102,7 @@ private:
         ChannelProcessRequester::shared_pointer const & channelProcessRequester,
         PVRecordPtr const &pvRecord,
         int nProcess)
-    : 
+    :
       channelLocal(channelLocal),
       channelProcessRequester(channelProcessRequester),
       pvRecord(pvRecord),
@@ -235,7 +235,7 @@ private:
         PVStructurePtr const&pvStructure,
         BitSetPtr const & bitSet,
         PVRecordPtr const &pvRecord)
-    : 
+    :
       firstTime(true),
       callProcess(callProcess),
       channelLocal(channelLocal),
@@ -523,7 +523,7 @@ void ChannelPutLocal::put(
     PVRecordPtr pvr(pvRecord.lock());
     if(!pvr) throw std::logic_error("pvRecord is deleted");
     try {
-        {   
+        {
             epicsGuard <PVRecord> guard(*pvr);
             pvr->beginGroupPut();
             pvCopy->updateMaster(pvStructure, bitSet);
@@ -534,7 +534,7 @@ void ChannelPutLocal::put(
         }
         requester->putDone(Status::Ok,getPtrSelf());
         if(pvr->getTraceLevel()>1)
-        {   
+        {
             cout << "ChannelPutLocal::put" << endl;
         }
     } catch(std::exception& ex) {
@@ -581,7 +581,7 @@ private:
         PVStructurePtr const&pvGetStructure,
         BitSetPtr const & getBitSet,
         PVRecordPtr const &pvRecord)
-    : 
+    :
       callProcess(callProcess),
       channelLocal(channelLocal),
       channelPutGetRequester(channelPutGetRequester),
@@ -887,7 +887,7 @@ void ChannelRPCLocal::processRequest(
         status = Status(Status::STATUSTYPE_FATAL, "Unexpected exception caught while calling RPCService.request(PVStructure).");
         ok = false;
     }
-    
+
     // check null result
     if (ok && !result)
     {
@@ -986,7 +986,7 @@ private:
         PVArrayPtr const &pvArray,
         PVArrayPtr const &pvCopy,
         PVRecordPtr const &pvRecord)
-    : 
+    :
       channelLocal(channelLocal),
       channelArrayRequester(channelArrayRequester),
       pvArray(pvArray),
@@ -1228,7 +1228,7 @@ ChannelLocal::ChannelLocal(
     ChannelProviderLocalPtr const & provider,
     ChannelRequester::shared_pointer const & requester,
     PVRecordPtr const & pvRecord)
-:   
+:
     requester(requester),
     provider(provider),
     pvRecord(pvRecord)
@@ -1273,7 +1273,7 @@ string ChannelLocal::getRequesterName()
          << " requester exists " << (requester ? "true" : "false")
          << endl;
     }
-    
+
     if(!requester) return string();
     return requester->getRequesterName();
 }
@@ -1296,7 +1296,7 @@ void ChannelLocal::message(
     string recordName("record deleted");
     if(pvr) recordName = pvr->getRecordName();
     cout << recordName
-         << " message " << message 
+         << " message " << message
          << " messageType " << getMessageTypeName(messageType)
          << endl;
 }
@@ -1339,8 +1339,8 @@ void ChannelLocal::getField(GetFieldRequester::shared_pointer const &requester,
             pvr->getPVRecordStructure()->getPVStructure()->getStructure();
         requester->getDone(Status::Ok,structure);
         return;
-    } 
-    PVFieldPtr pvField = 
+    }
+    PVFieldPtr pvField =
         pvr->getPVRecordStructure()->getPVStructure()->getSubField(subField);
     if(pvField) {
         requester->getDone(Status::Ok,pvField->getField());
@@ -1456,7 +1456,7 @@ ChannelRPC::shared_pointer ChannelLocal::createChannelRPC(
          << endl;
     }
 
-    ChannelRPCLocalPtr channelRPC = 
+    ChannelRPCLocalPtr channelRPC =
         ChannelRPCLocal::create(
             getPtrSelf(),
             channelRPCRequester,

--- a/src/pvAccess/channelProviderLocal.cpp
+++ b/src/pvAccess/channelProviderLocal.cpp
@@ -30,13 +30,13 @@ using std::cout;
 using std::endl;
 using std::string;
 
-namespace epics { namespace pvDatabase { 
+namespace epics { namespace pvDatabase {
 
 static string providerName("local");
 static ChannelProviderLocalPtr channelProvider;
 
 class LocalChannelProviderFactory : public ChannelProviderFactory
-{  
+{
 public:
     POINTER_DEFINITIONS(LocalChannelProviderFactory);
     virtual string getFactoryName() { return providerName;}
@@ -114,7 +114,7 @@ ChannelFind::shared_pointer ChannelProviderLocal::channelFind(
             Status::Ok,
             shared_from_this(),
             true);
-        
+
     } else {
         Status notFoundStatus(Status::STATUSTYPE_ERROR,"pv not found");
         channelFindRequester->channelFindResult(

--- a/src/pvAccess/monitorFactory.cpp
+++ b/src/pvAccess/monitorFactory.cpp
@@ -34,7 +34,7 @@ using std::cout;
 using std::endl;
 using std::string;
 
-namespace epics { namespace pvDatabase { 
+namespace epics { namespace pvDatabase {
 
 class MonitorLocal;
 typedef std::tr1::shared_ptr<MonitorLocal> MonitorLocalPtr;
@@ -88,7 +88,7 @@ public:
         nextGetUsed = 0;
         nextReleaseUsed = 0;
     }
-    
+
     MonitorElementPtr getFree()
     {
         if(numberFree==0) return MonitorElementPtr();
@@ -98,7 +98,7 @@ public:
         if(nextGetFree>=size) nextGetFree = 0;
         return elements[ind];
     }
-    
+
     void setUsed(MonitorElementPtr const &element)
     {
        if(element!=elements[nextSetUsed++]) {
@@ -107,7 +107,7 @@ public:
         numberUsed++;
         if(nextSetUsed>=size) nextSetUsed = 0;
     }
-    
+
     MonitorElementPtr getUsed()
     {
         if(numberUsed==0) return MonitorElementPtr();
@@ -131,7 +131,7 @@ public:
 
 typedef std::tr1::shared_ptr<MonitorRequester> MonitorRequesterPtr;
 
-    
+
 class MonitorLocal :
     public Monitor,
     public PVListener,

--- a/src/special/addRecord.cpp
+++ b/src/special/addRecord.cpp
@@ -37,7 +37,7 @@ using namespace epics::pvData;
 using namespace epics::pvAccess;
 using namespace std;
 
-namespace epics { namespace pvDatabase { 
+namespace epics { namespace pvDatabase {
 
 AddRecordPtr AddRecord::create(
     std::string const & recordName)

--- a/src/special/addRecord.cpp
+++ b/src/special/addRecord.cpp
@@ -115,4 +115,3 @@ void AddRecord::process()
 
 
 }}
-

--- a/src/special/processRecord.cpp
+++ b/src/special/processRecord.cpp
@@ -38,7 +38,7 @@ using namespace epics::pvData;
 using namespace epics::pvAccess;
 using namespace std;
 
-namespace epics { namespace pvDatabase { 
+namespace epics { namespace pvDatabase {
 
 ProcessRecordPtr ProcessRecord::create(
     std::string const & recordName,double delay)
@@ -141,7 +141,7 @@ void ProcessRecord::run()
         if(runStop.tryWait()) {
              runReturn.signal();
              return;
-        }    
+        }
         if(delay>0.0) epicsThreadSleep(delay);
         epicsGuard<epics::pvData::Mutex> guard(mutex);
         PVRecordMap::iterator iter;

--- a/src/special/processRecord.cpp
+++ b/src/special/processRecord.cpp
@@ -164,4 +164,3 @@ void ProcessRecord::run()
 
 
 }}
-

--- a/src/special/removeRecord.cpp
+++ b/src/special/removeRecord.cpp
@@ -90,4 +90,3 @@ void RemoveRecord::process()
 
 
 }}
-

--- a/src/special/removeRecord.cpp
+++ b/src/special/removeRecord.cpp
@@ -36,7 +36,7 @@ using namespace epics::pvData;
 using namespace epics::pvAccess;
 using namespace std;
 
-namespace epics { namespace pvDatabase { 
+namespace epics { namespace pvDatabase {
 
 RemoveRecordPtr RemoveRecord::create(
     std::string const & recordName)

--- a/src/special/traceRecord.cpp
+++ b/src/special/traceRecord.cpp
@@ -93,4 +93,3 @@ void TraceRecord::process()
 
 
 }}
-

--- a/src/special/traceRecord.cpp
+++ b/src/special/traceRecord.cpp
@@ -35,7 +35,7 @@ using namespace epics::pvData;
 using namespace epics::pvAccess;
 using namespace std;
 
-namespace epics { namespace pvDatabase { 
+namespace epics { namespace pvDatabase {
 
 TraceRecordPtr TraceRecord::create(
     std::string const & recordName)

--- a/src/support/controlSupport.cpp
+++ b/src/support/controlSupport.cpp
@@ -25,7 +25,7 @@ using namespace epics::pvData;
 using namespace epics::pvAccess;
 using namespace std;
 
-namespace epics { namespace pvDatabase { 
+namespace epics { namespace pvDatabase {
 
 ControlSupport::~ControlSupport()
 {

--- a/src/support/controlSupport.cpp
+++ b/src/support/controlSupport.cpp
@@ -135,4 +135,3 @@ void ControlSupport::reset()
 
 
 }}
-

--- a/src/support/scalarAlarmSupport.cpp
+++ b/src/support/scalarAlarmSupport.cpp
@@ -26,7 +26,7 @@ using namespace epics::pvData;
 using namespace epics::pvAccess;
 using namespace std;
 
-namespace epics { namespace pvDatabase { 
+namespace epics { namespace pvDatabase {
 
 ScalarAlarmSupport::~ScalarAlarmSupport()
 {
@@ -83,7 +83,7 @@ bool ScalarAlarmSupport::init(
        pvHysteresis = pvScalarAlarm->getSubField<PVDouble>("hysteresis");
     }
     if(!pvScalarAlarm
-       || !pvLowAlarmLimit || !pvLowWarningLimit 
+       || !pvLowAlarmLimit || !pvLowWarningLimit
        || !pvLowWarningLimit || !pvHighAlarmLimit
        || !pvHysteresis)
     {

--- a/src/support/scalarAlarmSupport.cpp
+++ b/src/support/scalarAlarmSupport.cpp
@@ -216,4 +216,3 @@ void ScalarAlarmSupport::setAlarm(
 
 
 }}
-

--- a/test/src/listener.h
+++ b/test/src/listener.h
@@ -26,7 +26,7 @@
 
 #ifdef listenerEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#	undef listenerEpicsExportSharedSymbols
+#       undef listenerEpicsExportSharedSymbols
 #endif
 
 #include <shareLib.h>

--- a/test/src/listener.h
+++ b/test/src/listener.h
@@ -33,7 +33,7 @@
 
 //epicsShareFunc epics::pvData::PVStructurePtr createListener();
 
-namespace epics { namespace pvDatabase { 
+namespace epics { namespace pvDatabase {
 using namespace epics::pvData;
 using namespace std;
 
@@ -59,7 +59,7 @@ public:
     }
     virtual void dataPut(PVRecordFieldPtr const & pvRecordField)
     {
-        cout << "Listener::dataPut record " << recordName 
+        cout << "Listener::dataPut record " << recordName
         << " pvRecordField " << pvRecordField->getPVField()->getFullName()
         << endl;
     }
@@ -67,7 +67,7 @@ public:
         PVRecordStructurePtr const & requested,
         PVRecordFieldPtr const & pvRecordField)
     {
-        cout << "Listener::dataPut record " << recordName 
+        cout << "Listener::dataPut record " << recordName
         << " requested " << requested->getPVStructure()->getFullName()
         << " pvRecordField " << pvRecordField->getPVField()->getFullName()
         << endl;
@@ -84,7 +84,7 @@ public:
     {
          cout << "Listener::unlisten record " << recordName << endl;
     }
-   
+
 private:
     Listener(PVRecordPtr const & pvRecord)
     : pvCopy(

--- a/test/src/powerSupply.h
+++ b/test/src/powerSupply.h
@@ -32,7 +32,7 @@
 
 //epicsShareFunc epics::pvData::PVStructurePtr createPowerSupply();
 
-namespace epics { namespace pvDatabase { 
+namespace epics { namespace pvDatabase {
 
 class PowerSupply;
 typedef std::tr1::shared_ptr<PowerSupply> PowerSupplyPtr;

--- a/test/src/powerSupply.h
+++ b/test/src/powerSupply.h
@@ -25,7 +25,7 @@
 
 #ifdef powerSupplyEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#	undef powerSupplyEpicsExportSharedSymbols
+#       undef powerSupplyEpicsExportSharedSymbols
 #endif
 
 #include <shareLib.h>

--- a/test/src/recordClient.h
+++ b/test/src/recordClient.h
@@ -25,7 +25,7 @@
 
 #ifdef pvRecordClientEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#	undef pvRecordClientEpicsExportSharedSymbols
+#       undef pvRecordClientEpicsExportSharedSymbols
 #endif
 
 #include <shareLib.h>

--- a/test/src/recordClient.h
+++ b/test/src/recordClient.h
@@ -30,7 +30,7 @@
 
 #include <shareLib.h>
 
-namespace epics { namespace pvDatabase { 
+namespace epics { namespace pvDatabase {
 
 class RecordClient;
 typedef std::tr1::shared_ptr<RecordClient> RecordClientPtr;
@@ -59,7 +59,7 @@ public:
          std::cout << "RecordClient::detach record " << pvRecord->getRecordName() << std::endl;
          this->pvRecord.reset();
     }
-   
+
 private:
     RecordClient(PVRecordPtr const & pvRecord)
     : pvRecord(pvRecord)

--- a/test/src/testExampleRecord.cpp
+++ b/test/src/testExampleRecord.cpp
@@ -134,4 +134,3 @@ MAIN(testExampleRecord)
     test();
     return 0;
 }
-

--- a/test/src/testLocalProvider.cpp
+++ b/test/src/testLocalProvider.cpp
@@ -79,4 +79,3 @@ MAIN(testLocalProvider)
     test();
     return 0;
 }
-

--- a/test/src/testPVAServer.cpp
+++ b/test/src/testPVAServer.cpp
@@ -75,4 +75,3 @@ MAIN(testPVAServer)
     test();
     return 0;
 }
-

--- a/test/src/testPVCopy.cpp
+++ b/test/src/testPVCopy.cpp
@@ -401,4 +401,3 @@ MAIN(testPVCopy)
     powerSupplyTest();
     return 0;
 }
-

--- a/test/src/testPVCopy.cpp
+++ b/test/src/testPVCopy.cpp
@@ -273,7 +273,7 @@ static void testPVScalarArray(
         cout << endl;
     }
 }
-    
+
 static void scalarTest()
 {
     if(debug) {cout << endl << endl << "****scalarTest****" << endl;}

--- a/test/src/testPVRecord.cpp
+++ b/test/src/testPVRecord.cpp
@@ -103,4 +103,3 @@ MAIN(testPVRecord)
     powerSupplyTest();
     return 0;
 }
-

--- a/test/src/testPlugin.cpp
+++ b/test/src/testPlugin.cpp
@@ -107,7 +107,7 @@ static void arrayTest()
     uint32 nset = 0;
     size_t n = 10;
     shared_vector<double> values(n);
-    
+
     PVStructurePtr pvRecordStructure(getStandardPVField()->scalarArray(pvDouble,""));
     PVRecordPtr pvRecord(PVRecord::create("doubleArrayRecord",pvRecordStructure));
     PVStructurePtr pvRequest(CreateRequest::create()->createRequest("value[array=1:3]"));
@@ -153,7 +153,7 @@ static void unionArrayTest()
     size_t n = 10;
     shared_vector<double> values(n);
     for(size_t i=0; i<n; i++) values[i] = i + .06;
-    PVDoubleArrayPtr pvDoubleArray = 
+    PVDoubleArrayPtr pvDoubleArray =
         static_pointer_cast<PVDoubleArray>(PVDataCreate::getPVDataCreate()->createPVScalarArray(pvDouble));
     const shared_vector<const double> yyy(freeze(values));
     pvDoubleArray->putFrom(yyy);

--- a/test/src/testPlugin.cpp
+++ b/test/src/testPlugin.cpp
@@ -343,4 +343,3 @@ MAIN(testPlugin)
     ignoreTest();
     return 0;
 }
-


### PR DESCRIPTION
This is purely cosmetic:
1. There was a mess with tab character usage. Indention with spaces and tabs was mixed inconsistently sometimes with obviously different assumptions on tab width, even in the same file. This results in irregular, hard to read indents. Please stop using tabs in source code.
2. Clean up of space at end of line.
3. Clean up of empty lines at end of file.