### PR TITLE
remove all destroy methods

### DIFF
--- a/src/copy/pvCopy.cpp
+++ b/src/copy/pvCopy.cpp
@@ -428,11 +428,6 @@ PVCopy::PVCopy(
 {
 }
 
-void PVCopy::destroy()
-{
-    headNode.reset();
-}
-
 bool PVCopy::init(epics::pvData::PVStructurePtr const &pvRequest)
 {
     PVStructurePtr pvMasterStructure = pvMaster;

--- a/src/pv/channelProviderLocal.h
+++ b/src/pv/channelProviderLocal.h
@@ -67,11 +67,6 @@ public:
      */
     virtual ~ChannelProviderLocal();
     /**
-     * @brief DEPRECATED
-     *
-     */
-    virtual void destroy(){};
-    /**
      * @brief Returns the channel provider name.
      *
      * @return <b>local</b>
@@ -190,11 +185,6 @@ public:
      * @brief Destructor
      */
     virtual ~ChannelLocal();
-    /**
-     * @brief DEPRECATED
-     *
-     */
-    virtual void destroy() {};
     /**
      * @brief Detach from the record.
      *

--- a/src/pv/pvDatabase.h
+++ b/src/pv/pvDatabase.h
@@ -87,10 +87,6 @@ public:
      */
     virtual void process();
     /**
-     *  @brief DEPRECATED
-     */
-    virtual void destroy() {}
-    /**
      *  @brief remove record from database.
      *
      * Remove the PVRecord. Release any resources used and

--- a/src/pv/pvStructureCopy.h
+++ b/src/pv/pvStructureCopy.h
@@ -79,7 +79,6 @@ public:
         epics::pvData::PVStructurePtr const &pvRequest,
         std::string const & structureName);
     virtual ~PVCopy(){}
-    virtual void destroy();
     /**
      * Get the top-level structure of master
      * @returns The master top-level structure.

--- a/src/pvAccess/channelLocal.cpp
+++ b/src/pvAccess/channelLocal.cpp
@@ -80,7 +80,6 @@ class ChannelProcessLocal :
 public:
     POINTER_DEFINITIONS(ChannelProcessLocal);
     virtual ~ChannelProcessLocal();
-    virtual void destroy() {} // DEPRECATED
     static ChannelProcessLocalPtr create(
         ChannelLocalPtr const &channelLocal,
         ChannelProcessRequester::shared_pointer const & channelProcessRequester,
@@ -210,7 +209,6 @@ class ChannelGetLocal :
 public:
     POINTER_DEFINITIONS(ChannelGetLocal);
     virtual ~ChannelGetLocal();
-    virtual void destroy() {} // DEPRECATED
     static ChannelGetLocalPtr create(
         ChannelLocalPtr const &channelLocal,
         ChannelGetRequester::shared_pointer const & channelGetRequester,
@@ -381,7 +379,6 @@ class ChannelPutLocal :
 public:
     POINTER_DEFINITIONS(ChannelPutLocal);
     virtual ~ChannelPutLocal();
-    virtual void destroy() {} // DEPRECATED
     static ChannelPutLocalPtr create(
         ChannelLocalPtr const &channelLocal,
         ChannelPutRequester::shared_pointer const & channelPutRequester,
@@ -551,7 +548,6 @@ class ChannelPutGetLocal :
 public:
     POINTER_DEFINITIONS(ChannelPutGetLocal);
     virtual ~ChannelPutGetLocal();
-    virtual void destroy() {} // DEPRECATED
     static ChannelPutGetLocalPtr create(
         ChannelLocalPtr const &channelLocal,
         ChannelPutGetRequester::shared_pointer const & channelPutGetRequester,
@@ -766,7 +762,6 @@ class ChannelRPCLocal :
 {
 public:
     POINTER_DEFINITIONS(ChannelRPCLocal);
-    virtual void destroy() {} // DEPRECATED
     static ChannelRPCLocalPtr create(
         ChannelLocalPtr const & channelLocal,
         ChannelRPCRequester::shared_pointer const & channelRPCRequester,
@@ -958,7 +953,6 @@ class ChannelArrayLocal :
 public:
     POINTER_DEFINITIONS(ChannelArrayLocal);
     virtual ~ChannelArrayLocal();
-    virtual void destroy() {} // DEPRECATED
     static ChannelArrayLocalPtr create(
         ChannelLocalPtr const &channelLocal,
         ChannelArrayRequester::shared_pointer const & channelArrayRequester,

--- a/src/pvAccess/monitorFactory.cpp
+++ b/src/pvAccess/monitorFactory.cpp
@@ -141,7 +141,6 @@ class MonitorLocal :
 public:
     POINTER_DEFINITIONS(MonitorLocal);
     virtual ~MonitorLocal();
-    virtual void destroy() {} // DEPRECATED
     virtual Status start();
     virtual Status stop();
     virtual MonitorElementPtr poll();

--- a/test/src/powerSupply.h
+++ b/test/src/powerSupply.h
@@ -46,7 +46,6 @@ public:
         std::string const & recordName,
         epics::pvData::PVStructurePtr const & pvStructure);
     virtual ~PowerSupply();
-    virtual void destroy();
     virtual bool init();
     virtual void process();
     void put(double power,double voltage);
@@ -109,11 +108,6 @@ inline PowerSupply::PowerSupply(
 
 inline PowerSupply::~PowerSupply()
 {
-}
-
-inline void PowerSupply::destroy()
-{
-    PVRecord::destroy();
 }
 
 inline bool PowerSupply::init()


### PR DESCRIPTION
For at least the last couple of epics7 releases pvDatabase.cpp has only had empty destroy methods.

In pvAccessCPP, destroyable.h now provides a default implementation of method destroy.
Thus pvDatabaseCPP no longer needs to implement destroy.

It is important to remove destroy so that code that uses pvDatabase is not tempted to implement destroy.