### PR TITLE
Enable Access Security

### DIFF
--- a/src/database/pvRecord.cpp
+++ b/src/database/pvRecord.cpp
@@ -37,9 +37,11 @@ namespace epics { namespace pvDatabase {
 
 PVRecordPtr PVRecord::create(
     string const &recordName,
-    PVStructurePtr const & pvStructure)
+    PVStructurePtr const & pvStructure,
+    int asLevel,
+    const std::string& asGroup)
 {
-    PVRecordPtr pvRecord(new PVRecord(recordName,pvStructure));
+    PVRecordPtr pvRecord(new PVRecord(recordName,pvStructure,asLevel,asGroup));
     if(!pvRecord->init()) {
         pvRecord.reset();
     }
@@ -49,12 +51,16 @@ PVRecordPtr PVRecord::create(
 
 PVRecord::PVRecord(
     string const & recordName,
-    PVStructurePtr const & pvStructure)
+    PVStructurePtr const & pvStructure,
+    int asLevel_,
+    const std::string& asGroup_)
 : recordName(recordName),
   pvStructure(pvStructure),
   depthGroupPut(0),
   traceLevel(0),
-  isAddListener(false)
+  isAddListener(false),
+  asLevel(asLevel_),
+  asGroup(asGroup_)
 {
 }
 

--- a/src/pv/channelProviderLocal.h
+++ b/src/pv/channelProviderLocal.h
@@ -27,6 +27,7 @@
 #include <pv/pvDatabase.h>
 
 #include <shareLib.h>
+#include <asLib.h>
 
 namespace epics { namespace pvDatabase {
 
@@ -58,6 +59,19 @@ class epicsShareClass ChannelProviderLocal :
 {
 public:
     POINTER_DEFINITIONS(ChannelProviderLocal);
+    /**
+     * @brief Initialize access security configuration
+     * @param filePath AS definition file path 
+     * @param substitutions macro substitutions
+     * @throws std::runtime_error in case of configuration problem 
+     */
+    static void initAs(const std::string& filePath, const std::string& substitutions="");
+    /**
+     * @brief Is access security active?
+     * @return true is AS is active
+     */
+    static bool isAsActive();
+
     /**
      * @brief Constructor
      */
@@ -157,6 +171,7 @@ private:
     int traceLevel;
     friend class ChannelProviderLocalRun;
 };
+
 
 /**
  * @brief Channel for accessing a PVRecord.
@@ -341,6 +356,12 @@ public:
      * @param out the stream on which the message is displayed.
      */
     virtual void printInfo(std::ostream& out);
+    /**
+     * @brief determines if client can write
+     *
+     * @return true if client can write
+     */
+    virtual bool canWrite();
 protected:
     shared_pointer getPtrSelf()
     {
@@ -351,6 +372,19 @@ private:
     ChannelProviderLocalWPtr provider;
     PVRecordWPtr pvRecord;
     epics::pvData::Mutex mutex;
+
+    // AS-specific variables/methods
+    std::vector<char> toCharArray(const std::string& s);
+    std::vector<char> getAsGroup(const PVRecordPtr& pvRecord);
+    std::vector<char> getAsUser(const epics::pvAccess::ChannelRequester::shared_pointer& requester);
+    std::vector<char> getAsHost(const epics::pvAccess::ChannelRequester::shared_pointer& requester);
+
+    int asLevel;
+    std::vector<char> asGroup;
+    std::vector<char> asUser;
+    std::vector<char> asHost;
+    ASMEMBERPVT asMemberPvt;
+    ASCLIENTPVT asClientPvt;
 };
 
 }}

--- a/src/pv/pvDatabase.h
+++ b/src/pv/pvDatabase.h
@@ -59,6 +59,7 @@ class epicsShareClass PVRecord :
 {
 public:
     POINTER_DEFINITIONS(PVRecord);
+    
     /**
      * The Destructor.
      */
@@ -112,11 +113,14 @@ public:
      *
      * @param recordName The name of the record, which is also the channelName.
      * @param pvStructure The top level structure.
+     * @param asLevel AS level (default: ASL0)
+     * @param asGroup AS group (default: DEFAULT)
      * @return A shared pointer to the newly created record.
      */
     static PVRecordPtr create(
         std::string const & recordName,
-        epics::pvData::PVStructurePtr const & pvStructure);
+        epics::pvData::PVStructurePtr const & pvStructure,
+        int asLevel = 0, const std::string& asGroup = "DEFAULT");
     /**
      * @brief  Get the name of the record.
      *
@@ -232,15 +236,30 @@ public:
      * @param level The level
      */
     void setTraceLevel(int level) {traceLevel = level;}
+    /**
+     * @brief Get the ASlevel 
+     *
+     * @return The level.
+     */
+    int getAsLevel() const {return asLevel;}
+    /**
+     * @brief Get the AS group name 
+     *
+     * @return The name.
+     */
+    std::string getAsGroup() const {return asGroup;}
 protected:
     /**
      * @brief Constructor
      * @param recordName The name of the record
      * @param pvStructure The top level PVStructutre
+     * @param asLevel AS level (default: ASL0)
+     * @param asGroup AS group (default: DEFAULT)
      */
     PVRecord(
         std::string const & recordName,
-        epics::pvData::PVStructurePtr const & pvStructure);
+        epics::pvData::PVStructurePtr const & pvStructure,
+        int asLevel = 0, const std::string& asGroup = "DEFAULT");
     /**
      * @brief Initializes the base class.
      *
@@ -269,6 +288,9 @@ private:
 
     epics::pvData::PVTimeStamp pvTimeStamp;
     epics::pvData::TimeStamp timeStamp;
+
+    int asLevel;
+    std::string asGroup;
 };
 
 epicsShareFunc std::ostream& operator<<(std::ostream& o, const PVRecord& record);

--- a/src/pvAccess/channelProviderLocal.cpp
+++ b/src/pvAccess/channelProviderLocal.cpp
@@ -10,6 +10,7 @@
  */
 
 #include <epicsThread.h>
+#include <asLib.h>
 #include <pv/serverContext.h>
 #include <pv/syncChannelFind.h>
 #include <pv/pvTimeStamp.h>
@@ -175,5 +176,19 @@ Channel::shared_pointer ChannelProviderLocal::createChannel(
     if(!address.empty()) throw std::invalid_argument("address not allowed for local implementation");
     return createChannel(channelName, channelRequester, priority);
 }
+
+void ChannelProviderLocal::initAs(const std::string& filePath, const std::string& substitutions)
+{
+    int status = asInitFile(filePath.c_str(), substitutions.c_str());
+    if(status) {
+        throw std::runtime_error("Invalid AS configuration.");
+    }
+}
+
+bool ChannelProviderLocal::isAsActive()
+{
+    return asActive;
+}
+
 
 }}


### PR DESCRIPTION
This PR enables access security for PV Database. There should be no changes in behavior for channel puts as long as AS has not been initialized. 