### PR TITLE
changes were made to all the special code, i.e. all pvdbcr*.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -20,6 +20,12 @@ INC += pv/pvSupport.h
 INC += pv/controlSupport.h
 INC += pv/scalarAlarmSupport.h
 
+INC += pv/pvdbcrScalar.h
+INC += pv/pvdbcrScalarArray.h
+INC += pv/pvdbcrAddRecord.h
+INC += pv/pvdbcrRemoveRecord.h
+INC += pv/pvdbcrProcessRecord.h
+INC += pv/pvdbcrTraceRecord.h
 
 include $(PVDATABASE_SRC)/copy/Makefile
 include $(PVDATABASE_SRC)/database/Makefile

--- a/src/pv/pvdbcrAddRecord.h
+++ b/src/pv/pvdbcrAddRecord.h
@@ -1,0 +1,67 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * EPICS pvData is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+/**
+ * @author mrk
+ * @date 2021.04.11
+ */
+#ifndef PVDBCRADDARRAY_H
+#define PVDBCRADDARRAY_H
+
+#include <pv/pvDatabase.h>
+#include <pv/pvSupport.h>
+#include <pv/pvStructureCopy.h>
+
+#include <shareLib.h>
+
+namespace epics { namespace pvDatabase {
+
+class PvdbcrAddRecord;
+typedef std::tr1::shared_ptr<PvdbcrAddRecord> PvdbcrAddRecordPtr;
+
+/**
+ * @brief  PvdbcrAddRecord A record that adds a record to the master database.
+ *
+ */
+class epicsShareClass PvdbcrAddRecord :
+     public PVRecord
+{
+private:
+  PvdbcrAddRecord(
+    std::string const & recordName,epics::pvData::PVStructurePtr const & pvStructure,
+    int asLevel,std::string const & asGroup);
+    epics::pvData::PVStringPtr pvRecordName;
+    epics::pvData::PVStringPtr pvResult;
+public:
+    POINTER_DEFINITIONS(PvdbcrAddRecord);
+    /**
+     * The Destructor.
+     */
+    virtual ~PvdbcrAddRecord() {}
+    /**
+     * @brief Create a record.
+     *
+     * @param recordName The record name.
+     * @param asLevel  The access security level.
+     * @param asGroup  The access security group.
+     * @return The PVRecord
+     */
+     static PvdbcrAddRecordPtr create(
+        std::string const & recordName,
+        int asLevel=0,std::string const & asGroup = std::string("DEFAULT"));
+    /**
+     *  @brief a PVRecord method
+     * @return success or failure
+     */
+    virtual bool init();
+    /**
+     *  @brief process method that adds a record to the master database.
+     */
+    virtual void process();
+};
+
+}}
+
+#endif  /* PVDBCRADDARRAY_H */

--- a/src/pv/pvdbcrProcessRecord.h
+++ b/src/pv/pvdbcrProcessRecord.h
@@ -1,0 +1,105 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * EPICS pvData is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+/**
+ * @author mrk
+ * @date 2021.04.11
+ */
+#ifndef PVDBCRPROCESSARRAY_H
+#define PVDBCRPROCESSARRAY_H
+#include <epicsThread.h>
+#include <epicsGuard.h>
+#include <pv/event.h>
+#include <pv/pvDatabase.h>
+#include <pv/pvSupport.h>
+#include <pv/pvStructureCopy.h>
+
+#include <shareLib.h>
+
+namespace epics { namespace pvDatabase {
+
+typedef std::tr1::shared_ptr<epicsThread> EpicsThreadPtr;
+class PvdbcrProcessRecord;
+typedef std::tr1::shared_ptr<PvdbcrProcessRecord> PvdbcrProcessRecordPtr;
+
+/**
+ * @brief  PvdbcrProcessRecord A record that processes other records in the master database.
+ *
+ */
+class epicsShareClass PvdbcrProcessRecord :
+     public PVRecord,
+     public epicsThreadRunable
+{
+private:
+    PvdbcrProcessRecord(
+        std::string const & recordName,epics::pvData::PVStructurePtr const & pvStructure,
+        double delay,
+        int asLevel,std::string const & asGroup);
+    double delay;
+    EpicsThreadPtr thread;
+    epics::pvData::Event runStop;
+    epics::pvData::Event runReturn;
+    PVDatabasePtr pvDatabase;
+    PVRecordMap pvRecordMap;
+    epics::pvData::PVStringPtr pvCommand;
+    epics::pvData::PVStringPtr pvRecordName;
+    epics::pvData::PVStringPtr pvResult;
+    epics::pvData::Mutex mutex;
+public:
+    POINTER_DEFINITIONS(PvdbcrProcessRecord);
+    /**
+     * The Destructor.
+     */
+    virtual ~PvdbcrProcessRecord() {}
+    /**
+     * @brief Create a record.
+     *
+     * @param recordName The record name.
+     * @param asLevel  The access security level.
+     * @param asGroup  The access security group.
+     * @return The PVRecord
+     */
+     static PvdbcrProcessRecordPtr create(
+        std::string const & recordName,
+        double delay= 1.0,
+        int asLevel=0,std::string const & asGroup = std::string("DEFAULT"));
+    /**
+     * @brief set the delay between prcocessing.
+     *
+     * @param delay in seconds
+     */    
+    void setDelay(double delay);
+     /**
+     * @brief get the delay between prcocessing.
+     *
+     * @return delay in seconds
+     */    
+    double getDelay();    
+    /**
+     *  @brief a PVRecord method
+     * @return success or failure
+     */
+    virtual bool init();
+    /**
+     *  @brief method that processes other records in the master database.
+     */
+    virtual void process();
+    /**
+     *  @brief thread method
+     */
+    virtual void run();
+    /**
+     *  @brief thread method
+     */
+    void startThread();
+    /**
+     *  @brief thread method
+     */
+    void stop();
+};
+
+}}
+
+#endif  /* PVDBCRPROCESSARRAY_H */

--- a/src/pv/pvdbcrRemoveRecord.h
+++ b/src/pv/pvdbcrRemoveRecord.h
@@ -1,0 +1,67 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * EPICS pvData is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+/**
+ * @author mrk
+ * @date 2021.04.11
+ */
+#ifndef PVDBCRREMOVEARRAY_H
+#define PVDBCRREMOVEARRAY_H
+
+#include <pv/pvDatabase.h>
+#include <pv/pvSupport.h>
+#include <pv/pvStructureCopy.h>
+
+#include <shareLib.h>
+
+namespace epics { namespace pvDatabase {
+
+class PvdbcrRemoveRecord;
+typedef std::tr1::shared_ptr<PvdbcrRemoveRecord> PvdbcrRemoveRecordPtr;
+
+/**
+ * @brief  PvdbcrRemoveRecord A record that removes a record from the master database.
+ *
+ */
+class epicsShareClass PvdbcrRemoveRecord :
+     public PVRecord
+{
+private:
+  PvdbcrRemoveRecord(
+    std::string const & recordName,epics::pvData::PVStructurePtr const & pvStructure,
+    int asLevel,std::string const & asGroup);
+    epics::pvData::PVStringPtr pvRecordName;
+    epics::pvData::PVStringPtr pvResult;
+public:
+    POINTER_DEFINITIONS(PvdbcrRemoveRecord);
+    /**
+     * The Destructor.
+     */
+    virtual ~PvdbcrRemoveRecord() {}
+    /**
+     * @brief Create a record.
+     *
+     * @param recordName The record name.
+     * @param asLevel  The access security level.
+     * @param asGroup  The access security group.
+     * @return The PVRecord
+     */
+     static PvdbcrRemoveRecordPtr create(
+        std::string const & recordName,
+        int asLevel=0,std::string const & asGroup = std::string("DEFAULT"));
+    /**
+     *  @brief a PVRecord method
+     * @return success or failure
+     */
+    virtual bool init();
+    /**
+     *  @brief process method that removes a record from the master database.
+     */
+    virtual void process();
+};
+
+}}
+
+#endif  /* PVDBCRREMOVEARRAY_H */

--- a/src/pv/pvdbcrScalar.h
+++ b/src/pv/pvdbcrScalar.h
@@ -1,0 +1,57 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * EPICS pvData is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+/**
+ * @author mrk
+ * @date 2021.04.11
+ */
+#ifndef PVDBCRSCALAR_H
+#define PVDBCRSCALAR_H
+
+#include <pv/pvDatabase.h>
+#include <pv/pvSupport.h>
+#include <pv/pvStructureCopy.h>
+
+#include <shareLib.h>
+
+namespace epics { namespace pvDatabase {
+
+class PvdbcrScalar;
+typedef std::tr1::shared_ptr<PvdbcrScalar> PvdbcrScalarPtr;
+
+/**
+ * @brief  PvdbcrScalar creates a record with a scalar value, alarm, and timeStamp.
+ *
+ */
+class epicsShareClass PvdbcrScalar :
+     public PVRecord
+{
+private:
+  PvdbcrScalar(
+    std::string const & recordName,epics::pvData::PVStructurePtr const & pvStructure,
+    int asLevel,std::string const & asGroup);
+public:
+    POINTER_DEFINITIONS(PvdbcrScalar);
+    /**
+     * The Destructor.
+     */
+    virtual ~PvdbcrScalar() {}
+    /**
+     * @brief Create a record.
+     *
+     * @param recordName The record name.
+     * @param scalarType The type for the value field
+     * @param asLevel  The access security level.
+     * @param asGroup  The access security group.
+     * @return The PVRecord
+     */
+     static PvdbcrScalarPtr create(
+        std::string const & recordName,std::string const &  scalarType,
+        int asLevel=0,std::string const & asGroup = std::string("DEFAULT"));
+};
+
+}}
+
+#endif  /* PVDBCRSCALAR_H */

--- a/src/pv/pvdbcrScalarArray.h
+++ b/src/pv/pvdbcrScalarArray.h
@@ -1,0 +1,57 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * EPICS pvData is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+/**
+ * @author mrk
+ * @date 2021.04.11
+ */
+#ifndef PVDBCRSCALARARRAY_H
+#define PVDBCRSCALARARRAY_H
+
+#include <pv/pvDatabase.h>
+#include <pv/pvSupport.h>
+#include <pv/pvStructureCopy.h>
+
+#include <shareLib.h>
+
+namespace epics { namespace pvDatabase {
+
+class PvdbcrScalarArray;
+typedef std::tr1::shared_ptr<PvdbcrScalarArray> PvdbcrScalarArrayPtr;
+
+/**
+ * @brief  PvdbcrScalarArray creates a record with a scalar array value, alarm, and timeStamp.
+ *
+ */
+class epicsShareClass PvdbcrScalarArray :
+     public PVRecord
+{
+private:
+  PvdbcrScalarArray(
+    std::string const & recordName,epics::pvData::PVStructurePtr const & pvStructure,
+    int asLevel,std::string const & asGroup);
+public:
+    POINTER_DEFINITIONS(PvdbcrScalarArray);
+    /**
+     * The Destructor.
+     */
+    virtual ~PvdbcrScalarArray() {}
+    /**
+     * @brief Create a record.
+     *
+     * @param recordName The record name.
+     * @param scalarType The type for the value field
+     * @param asLevel  The access security level.
+     * @param asGroup  The access security group.
+     * @return The PVRecord
+     */
+     static PvdbcrScalarArrayPtr create(
+        std::string const & recordName,std::string const &  scalarType,
+        int asLevel=0,std::string const & asGroup = std::string("DEFAULT"));
+};
+
+}}
+
+#endif  /* PVDBCRSCALARARRAY_H */

--- a/src/pv/pvdbcrTraceRecord.h
+++ b/src/pv/pvdbcrTraceRecord.h
@@ -1,0 +1,68 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * EPICS pvData is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+/**
+ * @author mrk
+ * @date 2021.04.11
+ */
+#ifndef PVDBCRTRACEARRAY_H
+#define PVDBCRTRACEARRAY_H
+
+#include <pv/pvDatabase.h>
+#include <pv/pvSupport.h>
+#include <pv/pvStructureCopy.h>
+
+#include <shareLib.h>
+
+namespace epics { namespace pvDatabase {
+
+class PvdbcrTraceRecord;
+typedef std::tr1::shared_ptr<PvdbcrTraceRecord> PvdbcrTraceRecordPtr;
+
+/**
+ * @brief  PvdbcrTraceRecord A record sets trace level for a record in the master database.
+ *
+ */
+class epicsShareClass PvdbcrTraceRecord :
+     public PVRecord
+{
+private:
+  PvdbcrTraceRecord(
+    std::string const & recordName,epics::pvData::PVStructurePtr const & pvStructure,
+    int asLevel,std::string const & asGroup);
+    epics::pvData::PVStringPtr pvRecordName;
+    epics::pvData::PVIntPtr pvLevel;
+    epics::pvData::PVStringPtr pvResult;
+public:
+    POINTER_DEFINITIONS(PvdbcrTraceRecord);
+    /**
+     * The Destructor.
+     */
+    virtual ~PvdbcrTraceRecord() {}
+    /**
+     * @brief Create a record.
+     *
+     * @param recordName The record name.
+     * @param asLevel  The access security level.
+     * @param asGroup  The access security group.
+     * @return The PVRecord
+     */
+     static PvdbcrTraceRecordPtr create(
+        std::string const & recordName,
+        int asLevel=0,std::string const & asGroup = std::string("DEFAULT"));
+    /**
+     *  @brief a PVRecord method
+     * @return success or failure
+     */
+    virtual bool init();
+    /**
+     *  @brief process method that sets trace level for a record in the master database.
+     */
+    virtual void process();
+};
+
+}}
+
+#endif  /* PVDBCRTRACEARRAY_H */

--- a/src/special/pvdbcrAddRecordRegister.cpp
+++ b/src/special/pvdbcrAddRecordRegister.cpp
@@ -22,35 +22,15 @@
 #include <epicsExport.h>
 #define epicsExportSharedSymbols
 #include "pv/pvDatabase.h"
+#include "pv/pvdbcrAddRecord.h"
 using namespace epics::pvData;
 using namespace std;
 
 namespace epics { namespace pvDatabase {
 
-class PvdbcrAddRecord;
-typedef std::tr1::shared_ptr<PvdbcrAddRecord> PvdbcrAddRecordPtr;
-
-
-class epicsShareClass PvdbcrAddRecord :
-    public PVRecord
-{
-private:
-    PvdbcrAddRecord(
-        std::string const & recordName,
-        epics::pvData::PVStructurePtr const & pvStructure);
-    PVStringPtr pvRecordName;
-    epics::pvData::PVStringPtr pvResult;
-public:
-    POINTER_DEFINITIONS(PvdbcrAddRecord);
-
-    static PvdbcrAddRecordPtr create(
-        std::string const & recordName);
-    virtual bool init();
-    virtual void process();
-};
-
 PvdbcrAddRecordPtr PvdbcrAddRecord::create(
-    std::string const & recordName)
+    std::string const & recordName,
+    int asLevel,std::string const & asGroup)
 {
     FieldCreatePtr fieldCreate = getFieldCreate();
     PVDataCreatePtr pvDataCreate = getPVDataCreate();
@@ -66,15 +46,16 @@ PvdbcrAddRecordPtr PvdbcrAddRecord::create(
         createStructure();
     PVStructurePtr pvStructure = pvDataCreate->createPVStructure(topStructure);
     PvdbcrAddRecordPtr pvRecord(
-        new PvdbcrAddRecord(recordName,pvStructure));
+        new PvdbcrAddRecord(recordName,pvStructure,asLevel,asGroup));
     if(!pvRecord->init()) pvRecord.reset();
     return pvRecord;
 }
 
 PvdbcrAddRecord::PvdbcrAddRecord(
     std::string const & recordName,
-    PVStructurePtr const & pvStructure)
-: PVRecord(recordName,pvStructure)
+    PVStructurePtr const & pvStructure,
+    int asLevel,std::string const & asGroup)
+: PVRecord(recordName,pvStructure,asLevel,asGroup)
 {
 }
 

--- a/src/special/pvdbcrRemoveRecordRegister.cpp
+++ b/src/special/pvdbcrRemoveRecordRegister.cpp
@@ -21,34 +21,15 @@
 #include <epicsExport.h>
 #define epicsExportSharedSymbols
 #include "pv/pvDatabase.h"
+#include "pv/pvdbcrRemoveRecord.h"
 using namespace epics::pvData;
 using namespace std;
 
 namespace epics { namespace pvDatabase {
 
-class PvdbcrRemoveRecord;
-typedef std::tr1::shared_ptr<PvdbcrRemoveRecord> PvdbcrRemoveRecordPtr;
-
-
-class epicsShareClass PvdbcrRemoveRecord :
-    public PVRecord
-{
-public:
-    POINTER_DEFINITIONS(PvdbcrRemoveRecord);
-    static PvdbcrRemoveRecordPtr create(
-        std::string const & recordName);
-    virtual bool init();
-    virtual void process();
-private:
-    PvdbcrRemoveRecord(
-        std::string const & recordName,
-        epics::pvData::PVStructurePtr const & pvStructure);
-    epics::pvData::PVStringPtr pvRecordName;
-    epics::pvData::PVStringPtr pvResult;
-};
-
 PvdbcrRemoveRecordPtr PvdbcrRemoveRecord::create(
-    std::string const & recordName)
+    std::string const & recordName,
+    int asLevel,std::string const & asGroup)
 {
     FieldCreatePtr fieldCreate = getFieldCreate();
     PVDataCreatePtr pvDataCreate = getPVDataCreate();
@@ -62,15 +43,17 @@ PvdbcrRemoveRecordPtr PvdbcrRemoveRecord::create(
         createStructure();
     PVStructurePtr pvStructure = pvDataCreate->createPVStructure(topStructure);
     PvdbcrRemoveRecordPtr pvRecord(
-        new PvdbcrRemoveRecord(recordName,pvStructure));
+        new PvdbcrRemoveRecord(recordName,pvStructure,
+        asLevel,asGroup));
     if(!pvRecord->init()) pvRecord.reset();
     return pvRecord;
 }
 
 PvdbcrRemoveRecord::PvdbcrRemoveRecord(
     std::string const & recordName,
-    epics::pvData::PVStructurePtr const & pvStructure)
-: PVRecord(recordName,pvStructure)
+    epics::pvData::PVStructurePtr const & pvStructure,
+    int asLevel,std::string const & asGroup)
+: PVRecord(recordName,pvStructure,asLevel,asGroup)
 {
 }
 

--- a/src/special/pvdbcrScalarArrayRegister.cpp
+++ b/src/special/pvdbcrScalarArrayRegister.cpp
@@ -7,9 +7,6 @@
  * @author mrk
  * @date 2021.04.07
  */
-
-
-/* Author: Marty Kraimer */
 #include <iocsh.h>
 #include <pv/standardField.h>
 #include <pv/standardPVField.h>
@@ -24,9 +21,38 @@
 // The following must be the last include for code pvDatabase implements
 #include <epicsExport.h>
 #define epicsExportSharedSymbols
+#include "pv/pvdbcrScalarArray.h"
 #include "pv/pvDatabase.h"
 using namespace epics::pvData;
 using namespace std;
+
+namespace epics { namespace pvDatabase {
+
+PvdbcrScalarArray::PvdbcrScalarArray(
+    std::string const & recordName,epics::pvData::PVStructurePtr const & pvStructure,
+    int asLevel,std::string const & asGroup)
+: PVRecord(recordName,pvStructure,asLevel,asGroup)
+{}
+
+PvdbcrScalarArrayPtr PvdbcrScalarArray::create(
+    std::string const & recordName,std::string const &  scalarType,
+    int asLevel,std::string const & asGroup)
+{
+    ScalarType st = epics::pvData::ScalarTypeFunc::getScalarType(scalarType);
+    FieldCreatePtr fieldCreate = getFieldCreate();
+    StandardFieldPtr standardField = getStandardField();
+    PVDataCreatePtr pvDataCreate = getPVDataCreate();
+    StructureConstPtr top = fieldCreate->createFieldBuilder()->
+        addArray("value",st) ->
+        add("timeStamp",standardField->timeStamp()) ->
+        add("alarm",standardField->alarm()) ->
+            createStructure();
+    PVStructurePtr pvStructure = pvDataCreate->createPVStructure(top);   
+    PvdbcrScalarArrayPtr pvRecord(new PvdbcrScalarArray(recordName,pvStructure,asLevel,asGroup));
+    pvRecord->initPVRecord();
+    return pvRecord;
+};
+}}
 
 static const iocshArg arg0 = { "recordName", iocshArgString };
 static const iocshArg arg1 = { "scalarType", iocshArgString };
@@ -54,21 +80,11 @@ static void pvdbcrScalarArrayCallFunc(const iocshArgBuf *args)
     if(sval) {
         asGroup = string(sval);
     }
-    ScalarType st = epics::pvData::ScalarTypeFunc::getScalarType(scalarType);
-    FieldCreatePtr fieldCreate = getFieldCreate();
-    StandardFieldPtr standardField = getStandardField();
-    PVDataCreatePtr pvDataCreate = getPVDataCreate();
-    StructureConstPtr top = fieldCreate->createFieldBuilder()->
-        addArray("value",st) ->
-        add("timeStamp",standardField->timeStamp()) ->
-        add("alarm",standardField->alarm()) ->
-        createStructure();
-    PVStructurePtr pvStructure = pvDataCreate->createPVStructure(top);   
-    epics::pvDatabase::PVRecordPtr record
-        = epics::pvDatabase::PVRecord::create(recordName,pvStructure);
+    epics::pvDatabase::PvdbcrScalarArrayPtr record
+        = epics::pvDatabase::PvdbcrScalarArray::create(recordName,scalarType);
+    epics::pvDatabase::PVDatabasePtr master = epics::pvDatabase::PVDatabase::getMaster();
     record->setAsLevel(asLevel);
     record->setAsGroup(asGroup);
-    epics::pvDatabase::PVDatabasePtr master = epics::pvDatabase::PVDatabase::getMaster();
     bool result =  master->addRecord(record);
     if(!result) cout << "recordname " << recordName << " not added" << endl;
 }

--- a/src/special/pvdbcrTraceRecordRegister.cpp
+++ b/src/special/pvdbcrTraceRecordRegister.cpp
@@ -22,34 +22,15 @@
 #include <epicsExport.h>
 #define epicsExportSharedSymbols
 #include "pv/pvDatabase.h"
+#include "pv/pvdbcrTraceRecord.h"
 using namespace epics::pvData;
 using namespace std;
 
 namespace epics { namespace pvDatabase {
 
-class PvdbcrTraceRecord;
-typedef std::tr1::shared_ptr<PvdbcrTraceRecord> PvdbcrTraceRecordPtr;
-
-class epicsShareClass PvdbcrTraceRecord :
-    public PVRecord
-{
-public:
-    POINTER_DEFINITIONS(PvdbcrTraceRecord);
-    static PvdbcrTraceRecordPtr create(
-        std::string const & recordName);
-    virtual bool init();
-    virtual void process();
-private:
-    PvdbcrTraceRecord(
-        std::string const & recordName,
-        epics::pvData::PVStructurePtr const & pvStructure);
-    epics::pvData::PVStringPtr pvRecordName;
-    epics::pvData::PVIntPtr pvLevel;
-    epics::pvData::PVStringPtr pvResult;
-}; 
-
 PvdbcrTraceRecordPtr PvdbcrTraceRecord::create(
-    std::string const & recordName)
+    std::string const & recordName,
+    int asLevel,std::string const & asGroup)
 {
     FieldCreatePtr fieldCreate = getFieldCreate();
     PVDataCreatePtr pvDataCreate = getPVDataCreate();
@@ -64,15 +45,16 @@ PvdbcrTraceRecordPtr PvdbcrTraceRecord::create(
         createStructure();
     PVStructurePtr pvStructure = pvDataCreate->createPVStructure(topStructure);
     PvdbcrTraceRecordPtr pvRecord(
-        new PvdbcrTraceRecord(recordName,pvStructure));
+        new PvdbcrTraceRecord(recordName,pvStructure,asLevel,asGroup));
     if(!pvRecord->init()) pvRecord.reset();
     return pvRecord;
 }
 
 PvdbcrTraceRecord::PvdbcrTraceRecord(
     std::string const & recordName,
-    epics::pvData::PVStructurePtr const & pvStructure)
-: PVRecord(recordName,pvStructure)
+    epics::pvData::PVStructurePtr const & pvStructure,
+    int asLevel,std::string const & asGroup)
+: PVRecord(recordName,pvStructure,asLevel,asGroup)
 {
 }
 


### PR DESCRIPTION
All now have a .h file in src/pv.
Each can now be used via an iocshell command or by a PVDatabase application that not part of an ioc database.