### PR TITLE
Exec testFail instead of exit(3) if channel is not connected

### DIFF
--- a/test/src/testChannelMonitor.cpp
+++ b/test/src/testChannelMonitor.cpp
@@ -138,9 +138,10 @@ class ChannelRequesterImpl : public ChannelRequester
 {
 private:
     Event event;
-    bool connected = false;
+    bool connected;
 
 public:
+    ChannelRequesterImpl() : connected(false) {}
 
     virtual string getRequesterName()
     {

--- a/test/src/testChannelMonitor.cpp
+++ b/test/src/testChannelMonitor.cpp
@@ -209,7 +209,7 @@ static void test()
     TR1::shared_ptr<ChannelRequesterImpl> channelRequesterImpl(new ChannelRequesterImpl());
 
     Channel::shared_pointer channel = provider->createChannel(recordName, channelRequesterImpl);
-    bool channelConnected = channelRequesterImpl->waitUntilConnected(1.0);
+    bool channelConnected = channelRequesterImpl->waitUntilConnected(2.0);
     testOk1(channelConnected);
     if (!channelConnected) {
         testAbort("Channel did not reach CONNECTED state");
@@ -223,7 +223,7 @@ static void test()
     PVStructure::shared_pointer pvRequest = CreateRequest::create()->createRequest(request);
     TR1::shared_ptr<ChannelMonitorRequesterImpl> cmRequesterImpl(new ChannelMonitorRequesterImpl(channel->getChannelName()));
     Monitor::shared_pointer monitor = channel->createMonitor(cmRequesterImpl, pvRequest);
-    bool monitorConnected = cmRequesterImpl->waitUntilConnected(1.0);
+    bool monitorConnected = cmRequesterImpl->waitUntilConnected(2.0);
     testOk1(monitorConnected);
     Status status = monitor->start();
     testOk1(status.isOK());
@@ -285,7 +285,7 @@ static void test()
     pvRequest = CreateRequest::create()->createRequest(request);
     cmRequesterImpl = TR1::shared_ptr<ChannelMonitorRequesterImpl>(new ChannelMonitorRequesterImpl(channel->getChannelName()));
     monitor = channel->createMonitor(cmRequesterImpl, pvRequest);
-    monitorConnected = cmRequesterImpl->waitUntilConnected(1.0);
+    monitorConnected = cmRequesterImpl->waitUntilConnected(2.0);
     testOk1(monitorConnected);
     status = monitor->start();
     testOk1(status.isOK());

--- a/test/src/testChannelMonitor.cpp
+++ b/test/src/testChannelMonitor.cpp
@@ -171,7 +171,8 @@ public:
         }
         else {
             cout << Channel::ConnectionStateNames[connectionState] << endl;
-            exit(3);
+            testFail("Channel did not reach CONNECTED state");
+            event.signal(); // To ensure the test does not hang
         }
     }
 


### PR DESCRIPTION
Resolves #84 